### PR TITLE
Move PATCH document_submissions to top level

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -160,7 +160,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var createdEvidenceRequest = DatabaseContext.EvidenceRequests.First();
             var createdDocumentSubmission = DatabaseContext.DocumentSubmissions.First();
 
-            var uri = new Uri($"api/v1/evidence_requests/{createdEvidenceRequest.Id}/document_submissions/{createdDocumentSubmission.Id}", UriKind.Relative);
+            var uri = new Uri($"api/v1/document_submissions/{createdDocumentSubmission.Id}", UriKind.Relative);
             string body = @"
             {
                 ""state"": ""UPLOADED""

--- a/EvidenceApi/V1/Controllers/DocumentSubmissionsController.cs
+++ b/EvidenceApi/V1/Controllers/DocumentSubmissionsController.cs
@@ -1,0 +1,48 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using EvidenceApi.V1.Boundary.Request;
+using EvidenceApi.V1.Boundary.Response.Exceptions;
+using EvidenceApi.V1.UseCase.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EvidenceApi.V1.Controllers
+{
+    [ApiController]
+    [Route("api/v1/document_submissions")]
+    [Produces("application/json")]
+    [ApiVersion("1.0")]
+    public class DocumentSubmissionsController : BaseController
+    {
+        private readonly IUpdateDocumentSubmissionStateUseCase _updateDocumentSubmissionStateUseCase;
+
+        public DocumentSubmissionsController(IUpdateDocumentSubmissionStateUseCase updateDocumentSubmissionStateUseCase)
+        {
+            _updateDocumentSubmissionStateUseCase = updateDocumentSubmissionStateUseCase;
+        }
+
+        /// <summary>
+        /// Updates the state of a document submission
+        /// </summary>
+        /// <response code="200">Updated</response>
+        /// <response code="400">Request contains invalid parameters</response>
+        /// <response code="404">Document submission cannot be found</response>
+        [HttpPatch]
+        [Route("{id}")]
+        public IActionResult UpdateDocumentSubmissionState([FromRoute][Required] Guid id, [FromBody] DocumentSubmissionRequest request)
+        {
+            try
+            {
+                var result = _updateDocumentSubmissionStateUseCase.Execute(id, request);
+                return Ok(result);
+            }
+            catch (BadRequestException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (NotFoundException ex)
+            {
+                return NotFound(ex.Message);
+            }
+        }
+    }
+}

--- a/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
+++ b/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
@@ -105,29 +105,5 @@ namespace EvidenceApi.V1.Controllers
             }
         }
 
-        /// <summary>
-        /// Updates the state of a document submission
-        /// </summary>
-        /// <response code="200">Updated</response>
-        /// <response code="400">Request contains invalid parameters</response>
-        /// <response code="404">Document submission cannot be found</response>
-        [HttpPatch]
-        [Route("{evidenceRequestId}/document_submissions/{id}")]
-        public IActionResult UpdateDocumentSubmissionState([FromRoute][Required] Guid id, [FromBody] DocumentSubmissionRequest request)
-        {
-            try
-            {
-                var result = _updateDocumentSubmissionStateUseCase.Execute(id, request);
-                return Ok(result);
-            }
-            catch (BadRequestException ex)
-            {
-                return BadRequest(ex.Message);
-            }
-            catch (NotFoundException ex)
-            {
-                return NotFound(ex.Message);
-            }
-        }
     }
 }


### PR DESCRIPTION
Moves PATCH DocumentSubmissions to top level, as the frontend doesn't always have access to the evidence request ID.

This will also make it easier when we need GET for the same resource.
