### PR TITLE
Bump the db instance size 

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -73,12 +73,12 @@ module "postgres_db_staging" {
   subnet_ids           = data.aws_subnet_ids.staging.ids
   db_engine            = "postgres"
   db_engine_version    = "11.10"
-  db_instance_class    = "db.t2.micro"
+  db_instance_class    = "db.t2.small"
   db_allocated_storage = 40
   maintenance_window   = "sun:10:00-sun:10:30"
   db_username          = data.aws_ssm_parameter.evidence_postgres_username.value
   db_password          = data.aws_ssm_parameter.evidence_postgres_db_password.value
-  storage_encrypted    = false
+  storage_encrypted    = true
   multi_az             = false //only true if production deployment
   publicly_accessible  = false
   project_name         = "platform apis"


### PR DESCRIPTION
because encryption is not supported on db.t2.micro

Raised this after HackIT folks enabled encryption on _all_ databases with https://github.com/LBHackney-IT/aws-hackney-common-terraform/pull/29/files

And we saw issues in CircleCI: https://app.circleci.com/pipelines/github/LBHackney-IT/evidence-api/211/workflows/dc897ce1-2ffb-4c53-8fda-9ea9e20052cc/jobs/815:
```
Error: Error creating DB Instance: InvalidParameterCombination: DB Instance class db.t2.micro does not support encryption at rest
	status code: 400, request id: 9df05d07-c6cf-45ea-a569-c4b5f1d63979
```