### PR TITLE
DES-75: search for a resident by reference number

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -52,11 +52,11 @@ namespace EvidenceApi.Tests.V1.E2ETests
             string expected = "{" +
                                "\"resident\":{" +
                                $"\"id\":\"{resident.Id}\"," +
+                               $"\"referenceId\":\"{created.ResidentReferenceId}\"," +
                                "\"name\":\"Frodo Baggins\"," +
                                "\"email\":\"frodo@bagend.com,\"," +
                                "\"phoneNumber\":\"+447123456789\"" +
                                "}," +
-                               $"\"residentReferenceId\":\"{created.ResidentReferenceId}\"," +
                                "\"deliveryMethods\":[\"SMS\"]," +
                                "\"documentTypes\":[" +
                                "{\"id\":\"proof-of-id\",\"title\":\"Proof of ID\",\"description\":\"A valid document that can be used to prove identity\"}" +

--- a/EvidenceApi.Tests/V1/E2ETests/ResidentsTests.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/ResidentsTests.cs
@@ -32,11 +32,18 @@ namespace EvidenceApi.Tests.V1.E2ETests
         {
             // Arrange
             var resident = TestDataHelper.Resident();
+            resident.Id = Guid.NewGuid();
+            var evidenceRequest = TestDataHelper.EvidenceRequest();
+            var serviceRequestedBy = "Development Housing Team";
+            evidenceRequest.ResidentId = resident.Id;
+            evidenceRequest.ServiceRequestedBy = serviceRequestedBy;
+
             DatabaseContext.Add(resident);
+            DatabaseContext.Add(evidenceRequest);
             DatabaseContext.SaveChanges();
 
             // Act
-            var uri = new Uri($"api/v1/residents/search/{resident.Name}", UriKind.Relative);
+            var uri = new Uri($"api/v1/residents/search/?serviceRequestedBy={serviceRequestedBy}&searchQuery={resident.Name}", UriKind.Relative);
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
 
             // Assert

--- a/EvidenceApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/EvidenceApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -15,8 +15,6 @@ namespace EvidenceApi.Tests.V1.Factories
         [Test]
         public void CanMapAnEvidenceRequestDomainObjectToAResponseObject()
         {
-            var documentType = new DocumentType() { Id = "passport", Title = "Passport" };
-
             var domain = TestDataHelper.EvidenceRequest();
             domain.DeliveryMethods = new List<DeliveryMethod> { DeliveryMethod.Email };
 
@@ -29,8 +27,7 @@ namespace EvidenceApi.Tests.V1.Factories
             response.Reason.Should().Be(response.Reason);
             response.DocumentTypes.Should().BeEquivalentTo(documentTypes);
             response.DeliveryMethods.Should().ContainSingle(x => x == "EMAIL");
-            response.Resident.Should().BeEquivalentTo(resident.ToResponse());
-            response.ResidentReferenceId.Should().Be(domain.ResidentReferenceId);
+            response.Resident.Should().BeEquivalentTo(resident.ToResponse(domain.ResidentReferenceId));
             response.Id.Should().Be(domain.Id);
             response.CreatedAt.Should().Be(domain.CreatedAt);
         }

--- a/EvidenceApi.Tests/V1/Gateways/EvidenceGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/EvidenceGatewayTests.cs
@@ -1,11 +1,8 @@
 #nullable enable annotations
 using System;
 using System.Linq;
-using AutoFixture;
 using EvidenceApi.V1.Domain;
-using EvidenceApi.V1.Factories;
 using EvidenceApi.V1.Gateways;
-using EvidenceApi.V1.Infrastructure;
 using FluentAssertions;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -333,6 +330,36 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             // Act
             var found = _classUnderTest.GetAll();
+
+            // Assert
+            found.Should().Equal(expected);
+        }
+
+        [Test]
+        public void CanGetEvidenceRequestsByServiceRequestedByAndResidentReferenceId()
+        {
+            // Arrange
+            var serviceRequestedBy = "Development Housing Team";
+            var residentReferenceId = "12345";
+            var request = new ResidentSearchQuery { ServiceRequestedBy = serviceRequestedBy, SearchQuery = residentReferenceId };
+
+            var evidenceRequest1 = TestDataHelper.EvidenceRequest();
+            evidenceRequest1.ServiceRequestedBy = serviceRequestedBy;
+            evidenceRequest1.ResidentReferenceId = residentReferenceId;
+            var evidenceRequest2 = TestDataHelper.EvidenceRequest();
+            evidenceRequest2.ServiceRequestedBy = serviceRequestedBy;
+            evidenceRequest2.ResidentReferenceId = "residentReferenceId";
+
+            DatabaseContext.EvidenceRequests.Add(evidenceRequest1);
+            DatabaseContext.EvidenceRequests.Add(evidenceRequest2);
+            DatabaseContext.SaveChanges();
+            var expected = new List<EvidenceRequest>()
+            {
+                evidenceRequest1
+            };
+
+            // Act
+            var found = _classUnderTest.GetEvidenceRequests(request);
 
             // Assert
             found.Should().Equal(expected);

--- a/EvidenceApi.Tests/V1/UseCase/CreateEvidenceRequestUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateEvidenceRequestUseCaseTests.cs
@@ -63,7 +63,6 @@ namespace EvidenceApi.Tests.V1.UseCase
             var result = _classUnderTest.Execute(_request);
 
             result.Resident.Id.Should().NotBeEmpty();
-            result.ResidentReferenceId.Should().NotBeEmpty();
             result.Resident.Name.Should().Be(_resident.Name);
             result.DocumentTypes.Should().OnlyContain(x => x.Id == _documentType.Id);
             result.DeliveryMethods.Should().BeEquivalentTo(_created.DeliveryMethods.ConvertAll(x => x.ToString().ToUpper()));

--- a/EvidenceApi/V1/Boundary/Request/ResidentSearchQuery.cs
+++ b/EvidenceApi/V1/Boundary/Request/ResidentSearchQuery.cs
@@ -1,0 +1,8 @@
+namespace EvidenceApi.V1.Boundary.Request
+{
+    public class ResidentSearchQuery
+    {
+        public string ServiceRequestedBy { get; set; }
+        public string SearchQuery { get; set; }
+    }
+}

--- a/EvidenceApi/V1/Boundary/Response/EvidenceRequestResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/EvidenceRequestResponse.cs
@@ -8,7 +8,6 @@ namespace EvidenceApi.V1.Boundary.Response
     public class EvidenceRequestResponse
     {
         public ResidentResponse Resident { get; set; }
-        public string ResidentReferenceId { get; set; }
         public List<string> DeliveryMethods { get; set; }
         public List<DocumentType> DocumentTypes { get; set; }
         public string ServiceRequestedBy { get; set; }

--- a/EvidenceApi/V1/Boundary/Response/ResidentResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/ResidentResponse.cs
@@ -5,6 +5,7 @@ namespace EvidenceApi.V1.Boundary.Response
     public class ResidentResponse
     {
         public Guid Id { get; set; }
+        public string ReferenceId { get; set; }
         public string Name { get; set; }
         public string Email { get; set; }
         public string PhoneNumber { get; set; }

--- a/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
+++ b/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
@@ -109,7 +109,7 @@ namespace EvidenceApi.V1.Controllers
         /// <response code="200">Found</response>
         /// <response code="400">Request contains invalid parameters</response>
         [HttpGet]
-        public IActionResult FilterEvidenceRequests([FromQuery] EvidenceRequestsSearchQuery request)
+        public IActionResult FilterEvidenceRequests([FromQuery][Required] EvidenceRequestsSearchQuery request)
         {
             try
             {

--- a/EvidenceApi/V1/Controllers/ResidentsController.cs
+++ b/EvidenceApi/V1/Controllers/ResidentsController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Boundary.Response.Exceptions;
 using EvidenceApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -48,10 +49,10 @@ namespace EvidenceApi.V1.Controllers
         /// <response code="200">Found</response>
         /// <response code="401">Request lacks valid API token</response>
         [HttpGet]
-        [Route("search/{searchQuery}")]
-        public IActionResult SearchResidents([FromRoute][Required] string searchQuery)
+        [Route("search")]
+        public IActionResult SearchResidents([FromQuery][Required] ResidentSearchQuery request)
         {
-            var result = _findResidentsBySearchQueryUseCase.Execute(searchQuery);
+            var result = _findResidentsBySearchQueryUseCase.Execute(request);
 
             return Ok(result);
         }

--- a/EvidenceApi/V1/Factories/ResponseFactory.cs
+++ b/EvidenceApi/V1/Factories/ResponseFactory.cs
@@ -11,8 +11,7 @@ namespace EvidenceApi.V1.Factories
         {
             return new EvidenceRequestResponse()
             {
-                Resident = resident.ToResponse(),
-                ResidentReferenceId = domain.ResidentReferenceId,
+                Resident = resident.ToResponse(domain.ResidentReferenceId),
                 DeliveryMethods = domain.DeliveryMethods.ConvertAll(x => x.ToString().ToUpper()),
                 DocumentTypes = documentTypes,
                 ServiceRequestedBy = domain.ServiceRequestedBy,
@@ -23,14 +22,15 @@ namespace EvidenceApi.V1.Factories
             };
         }
 
-        public static ResidentResponse ToResponse(this Resident domain)
+        public static ResidentResponse ToResponse(this Resident domain, string? referenceId = null)
         {
             return new ResidentResponse()
             {
                 Id = domain.Id,
                 Name = domain.Name,
                 Email = domain.Email,
-                PhoneNumber = domain.PhoneNumber
+                PhoneNumber = domain.PhoneNumber,
+                ReferenceId = referenceId
             };
         }
 

--- a/EvidenceApi/V1/Gateways/EvidenceGateway.cs
+++ b/EvidenceApi/V1/Gateways/EvidenceGateway.cs
@@ -50,7 +50,7 @@ namespace EvidenceApi.V1.Gateways
         {
             return _databaseContext.EvidenceRequests
                 .Where(x =>
-                    x.ServiceRequestedBy.Contains(request.ServiceRequestedBy) &&
+                    x.ServiceRequestedBy.Equals(request.ServiceRequestedBy) &&
                     (request.ResidentId == null || x.ResidentId.Equals(request.ResidentId)) &&
                     (request.State == null || x.State.Equals(request.State))
                 ).ToList();
@@ -74,6 +74,15 @@ namespace EvidenceApi.V1.Gateways
         public List<EvidenceRequest> GetAll()
         {
             return _databaseContext.EvidenceRequests.ToList();
+        }
+
+        public List<EvidenceRequest> GetEvidenceRequests(ResidentSearchQuery request)
+        {
+            return _databaseContext.EvidenceRequests
+                .Where(x =>
+                    x.ServiceRequestedBy.Equals(request.ServiceRequestedBy) &&
+                    x.ResidentReferenceId.Equals(request.SearchQuery)
+                ).ToList();
         }
     }
 }

--- a/EvidenceApi/V1/Gateways/Interfaces/IEvidenceGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IEvidenceGateway.cs
@@ -16,5 +16,6 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         List<DocumentSubmission> FindDocumentSubmissionsByEvidenceRequestId(Guid id);
         List<EvidenceRequest> FindEvidenceRequestsByResidentId(Guid id);
         List<EvidenceRequest> GetAll();
+        List<EvidenceRequest> GetEvidenceRequests(ResidentSearchQuery request);
     }
 }

--- a/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
@@ -21,40 +21,40 @@ namespace EvidenceApi.V1.UseCase
 
         public List<ResidentResponse> Execute(ResidentSearchQuery request)
         {
-            var results = new List<ResidentResponse>();
-            findByResidentDetails(request, results);
-            findByResidentReferenceId(request, results);
-            return results;
+            var residents = new List<ResidentResponse>();
+            findByResidentDetails(request, residents);
+            findByResidentReferenceId(request, residents);
+            return residents;
         }
 
-        private void findByResidentDetails(ResidentSearchQuery request, ICollection<ResidentResponse> results)
+        private void findByResidentDetails(ResidentSearchQuery request, ICollection<ResidentResponse> residents)
         {
-            var residentSearchByNameEmailPhoneNumber = _residentsGateway.FindResidents(request.SearchQuery);
+            var residentsForSearchQuery = _residentsGateway.FindResidents(request.SearchQuery);
 
-            foreach (var resident in residentSearchByNameEmailPhoneNumber)
+            foreach (var resident in residentsForSearchQuery)
             {
                 var evidenceRequestsForResident = _evidenceGateway.FindEvidenceRequestsByResidentId(resident.Id);
                 foreach (var evidenceRequest in evidenceRequestsForResident)
                 {
                     if (evidenceRequest.ServiceRequestedBy.Equals(request.ServiceRequestedBy))
                     {
-                        results.Add(resident.ToResponse(evidenceRequest.ResidentReferenceId));
+                        residents.Add(resident.ToResponse(evidenceRequest.ResidentReferenceId));
                         // if any of the evidence requests were created by ServiceRequestedBy from the query then this resident should be returned
-                        // we can then break out of the loop early
+                        // and we can then break out of the loop early.
                         break;
                     }
                 }
             }
         }
 
-        private void findByResidentReferenceId(ResidentSearchQuery request, ICollection<ResidentResponse> results)
+        private void findByResidentReferenceId(ResidentSearchQuery request, ICollection<ResidentResponse> residents)
         {
-            var evidenceRequestsByTeamAndResidentReferenceId = _evidenceGateway.GetEvidenceRequests(request);
-            if (evidenceRequestsByTeamAndResidentReferenceId.Count > 0)
+            var evidenceRequestsForTeamAndSearchQuery = _evidenceGateway.GetEvidenceRequests(request);
+            if (evidenceRequestsForTeamAndSearchQuery.Count > 0)
             {
-                var evidenceRequest = evidenceRequestsByTeamAndResidentReferenceId.First();
-                var residentByTeamAndResidentReferenceId = _residentsGateway.FindResident(evidenceRequest.ResidentId);
-                results.Add(residentByTeamAndResidentReferenceId.ToResponse(evidenceRequest.ResidentReferenceId));
+                var evidenceRequest = evidenceRequestsForTeamAndSearchQuery.First();
+                var residentForTeamAndSearchQuery = _residentsGateway.FindResident(evidenceRequest.ResidentId);
+                residents.Add(residentForTeamAndSearchQuery.ToResponse(evidenceRequest.ResidentReferenceId));
             }
         }
     }

--- a/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Boundary.Response;
 using EvidenceApi.V1.Factories;
 using EvidenceApi.V1.Gateways.Interfaces;
@@ -10,17 +11,51 @@ namespace EvidenceApi.V1.UseCase
     public class FindResidentsBySearchQueryUseCase : IFindResidentsBySearchQueryUseCase
     {
         private readonly IResidentsGateway _residentsGateway;
+        private readonly IEvidenceGateway _evidenceGateway;
 
-        public FindResidentsBySearchQueryUseCase(IResidentsGateway residentsGateway)
+        public FindResidentsBySearchQueryUseCase(IResidentsGateway residentsGateway, IEvidenceGateway evidenceGateway)
         {
             _residentsGateway = residentsGateway;
+            _evidenceGateway = evidenceGateway;
         }
 
-        public List<ResidentResponse> Execute(string searchQuery)
+        public List<ResidentResponse> Execute(ResidentSearchQuery request)
         {
-            var found = _residentsGateway.FindResidents(searchQuery);
+            var results = new List<ResidentResponse>();
+            findByResidentDetails(request, results);
+            findByResidentReferenceId(request, results);
+            return results;
+        }
 
-            return found.Select(r => r.ToResponse()).ToList();
+        private void findByResidentDetails(ResidentSearchQuery request, ICollection<ResidentResponse> results)
+        {
+            var residentSearchByNameEmailPhoneNumber = _residentsGateway.FindResidents(request.SearchQuery);
+
+            foreach (var resident in residentSearchByNameEmailPhoneNumber)
+            {
+                var evidenceRequestsForResident = _evidenceGateway.FindEvidenceRequestsByResidentId(resident.Id);
+                foreach (var evidenceRequest in evidenceRequestsForResident)
+                {
+                    if (evidenceRequest.ServiceRequestedBy.Equals(request.ServiceRequestedBy))
+                    {
+                        results.Add(resident.ToResponse(evidenceRequest.ResidentReferenceId));
+                        // if any of the evidence requests were created by ServiceRequestedBy from the query then this resident should be returned
+                        // we can then break out of the loop early
+                        break;
+                    }
+                }
+            }
+        }
+
+        private void findByResidentReferenceId(ResidentSearchQuery request, ICollection<ResidentResponse> results)
+        {
+            var evidenceRequestsByTeamAndResidentReferenceId = _evidenceGateway.GetEvidenceRequests(request);
+            if (evidenceRequestsByTeamAndResidentReferenceId.Count > 0)
+            {
+                var evidenceRequest = evidenceRequestsByTeamAndResidentReferenceId.First();
+                var residentByTeamAndResidentReferenceId = _residentsGateway.FindResident(evidenceRequest.ResidentId);
+                results.Add(residentByTeamAndResidentReferenceId.ToResponse(evidenceRequest.ResidentReferenceId));
+            }
         }
     }
 }

--- a/EvidenceApi/V1/UseCase/Interfaces/IFindResidentsBySearchQueryUseCase.cs
+++ b/EvidenceApi/V1/UseCase/Interfaces/IFindResidentsBySearchQueryUseCase.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Boundary.Response;
 
 namespace EvidenceApi.V1.UseCase.Interfaces
 {
     public interface IFindResidentsBySearchQueryUseCase
     {
-        List<ResidentResponse> Execute(string searchQuery);
+        List<ResidentResponse> Execute(ResidentSearchQuery request);
     }
 }


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-75

- `GET:resident/search` now takes `ServiceRequestedBy` and `SearchQuery`
  - This ensures we only retrieve residents for the provided service
- Move `ResidentReferenceId` from `EvidenceRequestResponse` to `ResidentResponse` because it's related to the resident
- Search `residents` table for the `SearchQuery` first, then `evidence_requests` for the resident reference ID, and return all matches