### PR TITLE
Improve the exception thrown by gov notify

### DIFF
--- a/EvidenceApi/V1/Boundary/Response/Exceptions/NotificationException.cs
+++ b/EvidenceApi/V1/Boundary/Response/Exceptions/NotificationException.cs
@@ -1,16 +1,12 @@
 using System;
-using EvidenceApi.V1.Domain;
-using FluentValidation.Results;
 
 namespace EvidenceApi.V1.Boundary.Response.Exceptions
 {
     public class NotificationException : Exception
     {
-        private readonly EvidenceRequest _evidenceRequest;
-
-        public NotificationException(EvidenceRequest evidenceRequest) : base("Evidence request created, but something went wrong sending a notification using .Gov Notify")
+        public NotificationException(string message) : base(message)
         {
-            _evidenceRequest = evidenceRequest;
+
         }
     }
 }

--- a/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
+++ b/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
@@ -53,7 +53,7 @@ namespace EvidenceApi.V1.Controllers
             }
             catch (NotificationException ex)
             {
-                return StatusCode(500, ex.Message);
+                return StatusCode(400, ex.Message);
             }
         }
 

--- a/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
@@ -120,8 +120,6 @@ namespace EvidenceApi.V1.UseCase
                     throw new NotificationException(
                         "There was an error sending the request by " +
                         String.Join(", ", exceptions).ToLower() +
-                        ". The request was still sent by " +
-                        String.Join(", ", successfulDeliveryMethods).ToLower() +
                         "."
                     );
                 }

--- a/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
@@ -9,6 +9,8 @@ using EvidenceApi.V1.Gateways.Interfaces;
 using EvidenceApi.V1.UseCase.Interfaces;
 using Notify.Exceptions;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace EvidenceApi.V1.UseCase
 {
@@ -56,16 +58,24 @@ namespace EvidenceApi.V1.UseCase
             var evidenceRequest = BuildEvidenceRequest(request, resident.Id, residentReferenceId);
             var created = _evidenceGateway.CreateEvidenceRequest(evidenceRequest);
 
-            try
-            {
-                created.DeliveryMethods.ForEach(dm =>
-                    _notifyGateway.SendNotification(dm, CommunicationReason.EvidenceRequest, created, resident));
-            }
-            catch (NotifyClientException ex)
-            {
-                _logger.LogError(ex, ex.Message);
-                throw new NotificationException(created);
-            }
+            var exceptions = new List<DeliveryMethod>();
+
+            created.DeliveryMethods.ForEach(
+                dm =>
+                {
+                    try
+                    {
+                        _notifyGateway.SendNotification(dm, CommunicationReason.EvidenceRequest, created, resident);
+                    }
+                    catch (NotifyClientException e)
+                    {
+                        _logger.LogError(e, e.Message);
+                        exceptions.Add(dm);
+                    }
+                }
+            );
+
+            ThrowException(created.DeliveryMethods, exceptions);
 
             return created.ToResponse(resident, documentTypes);
         }
@@ -97,6 +107,30 @@ namespace EvidenceApi.V1.UseCase
         private DeliveryMethod ParseDeliveryMethod(string deliveryMethod)
         {
             return Enum.Parse<DeliveryMethod>(deliveryMethod, true);
+        }
+
+        private static void ThrowException(List<DeliveryMethod> deliveryMethods, List<DeliveryMethod> exceptions)
+        {
+            var successfulDeliveryMethods = deliveryMethods.Except(exceptions).ToList();
+
+            if (exceptions.Count != 0)
+            {
+                if (deliveryMethods.Count > 1)
+                {
+                    throw new NotificationException(
+                        "There was an error sending the request by " +
+                        String.Join(", ", exceptions).ToLower() +
+                        ". The request was still sent by " +
+                        String.Join(", ", successfulDeliveryMethods).ToLower() +
+                        "."
+                    );
+                }
+                throw new NotificationException(
+                    "There was an error sending the request by " +
+                    String.Join(", ", exceptions).ToLower() +
+                    "."
+                );
+            }
         }
     }
 }

--- a/EvidenceApi/V1/UseCase/UpdateDocumentSubmissionStateUseCase.cs
+++ b/EvidenceApi/V1/UseCase/UpdateDocumentSubmissionStateUseCase.cs
@@ -131,7 +131,7 @@ namespace EvidenceApi.V1.UseCase
             catch (NotifyClientException ex)
             {
                 _logger.LogError(ex, ex.Message);
-                throw new NotificationException(documentSubmission.EvidenceRequest);
+                throw new NotificationException(ex.Message);
             }
         }
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/projects/DES/boards/45?selectedIssue=DES-221

## Describe this PR

Updated the custom exception thrown when gov notify fails to send the notification via one of the delivery methods. By doing this we can pass to the frontend a more meaningful error message so the user understands what's going wrong.
