### PR TITLE
DES-309: forward multipart uploads from the frontend to DocumentsAPI

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -101,7 +101,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
                                $"\"state\":\"PENDING\"," +
                                "\"documentType\":{\"id\":\"proof-of-id\",\"title\":\"Proof of ID\",\"description\":\"A valid document that can be used to prove identity\"}," +
                                "\"staffSelectedDocumentType\":null," +
-                               $"\"uploadPolicy\":{JsonConvert.SerializeObject(_createdUploadPolicy, Formatting.None)}," +
                                "\"document\":null" +
                                "}";
 
@@ -147,50 +146,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
             DocumentsApiServer.Reset();
             DocumentsApiServer.Given(
                 Request.Create().WithPath("/api/v1/claims")
-            ).RespondWith(
-                Response.Create().WithStatusCode(404)
-            );
-
-            var uri = new Uri($"api/v1/evidence_requests/{entity.Id}/document_submissions", UriKind.Relative);
-            string body = @"
-            {
-                ""documentType"": ""proof-of-id"",
-                ""serviceName"": ""Development Housing Team"",
-                ""requesterEmail"": ""example@email""
-            }";
-
-            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
-
-            // Act
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
-
-            // Assert
-            response.StatusCode.Should().Be(400);
-        }
-
-        [Test]
-        public async Task CreateDocumentSubmissionUnsuccessfulWhenCannotCreateUploadPolicy()
-        {
-            // Arrange
-            var entity = _fixture.Build<EvidenceRequest>()
-                .With(x => x.DocumentTypes, new List<string> { "passport-scan" })
-                .With(x => x.DeliveryMethods, new List<DeliveryMethod> { DeliveryMethod.Email })
-                .Without(x => x.Communications)
-                .Without(x => x.DocumentSubmissions)
-                .Create();
-            DatabaseContext.EvidenceRequests.Add(entity);
-            DatabaseContext.SaveChanges();
-
-            DocumentsApiServer.Reset();
-            DocumentsApiServer.Given(
-                Request.Create().WithPath("/api/v1/claims")
-            ).RespondWith(
-                Response.Create().WithStatusCode(201).WithBody(
-                    JsonConvert.SerializeObject(_createdClaim)
-                )
-            );
-            DocumentsApiServer.Given(
-                Request.Create().WithPath($"/api/v1/documents/{id}/upload_policies")
             ).RespondWith(
                 Response.Create().WithStatusCode(404)
             );
@@ -338,7 +293,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var jsonFind = await responseFind.Content.ReadAsStringAsync().ConfigureAwait(true);
             var result = JsonConvert.DeserializeObject<DocumentSubmissionResponse>(jsonFind);
 
-            var expected = documentSubmission.ToResponse(null, null, null, _document);
+            var expected = documentSubmission.ToResponse(null, null, _document);
 
             responseFind.StatusCode.Should().Be(200);
             result.Should().BeEquivalentTo(expected);
@@ -413,8 +368,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             var expected = new List<DocumentSubmissionResponse>()
             {
-                documentSubmission1.ToResponse(documentType, null, null, _document),
-                documentSubmission2.ToResponse(documentType, null, null, _document)
+                documentSubmission1.ToResponse(documentType,  null, _document),
+                documentSubmission2.ToResponse(documentType,  null, _document)
             };
 
             response.StatusCode.Should().Be(200);

--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -88,7 +88,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                                $"\"createdAt\":{formattedCreatedAt}," +
                                $"\"claimId\":\"{_createdClaim.Id}\"," +
                                $"\"rejectionReason\":null," +
-                               $"\"state\":\"PENDING\"," +
+                               $"\"state\":\"UPLOADED\"," +
                                "\"documentType\":{\"id\":\"proof-of-id\",\"title\":\"Proof of ID\",\"description\":\"A valid document that can be used to prove identity\"}," +
                                "\"staffSelectedDocumentType\":null," +
                                "\"document\":null" +

--- a/EvidenceApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/EvidenceApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -50,9 +50,8 @@ namespace EvidenceApi.Tests.V1.Factories
         {
             var documentType = new DocumentType() { Id = "passport", Title = "Passport" };
             var domain = TestDataHelper.DocumentSubmission();
-            var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
 
-            var response = domain.ToResponse(documentType, null, s3UploadPolicy);
+            var response = domain.ToResponse(documentType);
 
             response.Id.Should().Be(domain.Id);
             response.CreatedAt.Should().Be(domain.CreatedAt);
@@ -60,7 +59,6 @@ namespace EvidenceApi.Tests.V1.Factories
             response.RejectionReason.Should().Be(domain.RejectionReason);
             response.State.Should().Be(domain.State.ToString().ToUpper());
             response.DocumentType.Should().Be(documentType);
-            response.UploadPolicy.Should().Be(s3UploadPolicy);
         }
     }
 }

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -93,7 +93,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             _documentType = _fixture.Create<DocumentType>();
             _created = DocumentSubmissionFixture();
             _request = CreateRequestFixture(evidenceRequest);
-;
+
             var claim = _fixture.Create<Claim>();
 
             SetupEvidenceGateway(evidenceRequest);

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using AutoFixture;
 using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Boundary.Response;
@@ -12,6 +14,7 @@ using Moq;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using EvidenceApi.V1.Domain.Enums;
+using Microsoft.AspNetCore.Http;
 
 namespace EvidenceApi.Tests.V1.UseCase
 {
@@ -47,7 +50,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         public void ThrowsNotFoundExceptionWhenEvidenceRequestIsNull()
         {
             var request = _fixture.Build<DocumentSubmissionRequest>()
-                .Without(x => x.Document)
+                .With(x => x.Document, new FormFile(new MemoryStream(Encoding.UTF8.GetBytes("This is a dummy file")), 0, 0, "Data", "dummy.txt"))
                 .Create();
             _evidenceGateway
                 .Setup(x => x.CreateDocumentSubmission(It.Is<DocumentSubmission>(x => x.DocumentTypeId == request.DocumentType)))
@@ -179,7 +182,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             return _fixture.Build<DocumentSubmissionRequest>()
                 .With(x => x.EvidenceRequestId, evidenceRequest.Id)
                 .With(x => x.DocumentType, _documentType.Id)
-                .Without(x => x.Document)
+                .With(x => x.Document, new FormFile(new MemoryStream(Encoding.UTF8.GetBytes("This is a dummy file")), 0, 0, "Data", "dummy.txt"))
                 .Create();
         }
 

--- a/EvidenceApi/V1/Boundary/Request/DocumentSubmissionRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/DocumentSubmissionRequest.cs
@@ -1,7 +1,14 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
 namespace EvidenceApi.V1.Boundary.Request
 {
     public class DocumentSubmissionRequest
     {
+        [FromRoute]
+        public Guid EvidenceRequestId { get; set; }
+        public IFormFile Document { get; set; }
         public string DocumentType { get; set; }
     }
 }

--- a/EvidenceApi/V1/Boundary/Request/DocumentSubmissionRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/DocumentSubmissionRequest.cs
@@ -3,7 +3,5 @@ namespace EvidenceApi.V1.Boundary.Request
     public class DocumentSubmissionRequest
     {
         public string DocumentType { get; set; }
-        public string State { get; set; }
-        public string StaffSelectedDocumentTypeId { get; set; } = null;
     }
 }

--- a/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
@@ -13,7 +13,6 @@ namespace EvidenceApi.V1.Boundary.Response
         public string State { get; set; }
         public DocumentType DocumentType { get; set; }
         public DocumentType? StaffSelectedDocumentType { get; set; }
-        public S3UploadPolicy? UploadPolicy { get; set; }
         public Document? Document { get; set; }
     }
 }

--- a/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
+++ b/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
@@ -87,12 +87,12 @@ namespace EvidenceApi.V1.Controllers
         /// <response code="404">Evidence request cannot be found</response>
         [HttpPost]
         [Route("{evidenceRequestId}/document_submissions")]
-        public async Task<IActionResult> CreateDocumentSubmission([FromRoute][Required] Guid evidenceRequestId, [FromBody][Required] DocumentSubmissionRequest request)
+        public async Task<IActionResult> CreateDocumentSubmission([FromForm] DocumentSubmissionRequest request)
         {
             try
             {
-                var result = await _createDocumentSubmission.ExecuteAsync(evidenceRequestId, request).ConfigureAwait(true);
-                return Created(new Uri($"/evidence_requests/{evidenceRequestId}/document_submissions", UriKind.Relative), result);
+                var result = await _createDocumentSubmission.ExecuteAsync(request).ConfigureAwait(true);
+                return Created(new Uri($"/evidence_requests/{request.EvidenceRequestId}/document_submissions", UriKind.Relative), result);
             }
             catch (BadRequestException ex)
             {

--- a/EvidenceApi/V1/Factories/ResponseFactory.cs
+++ b/EvidenceApi/V1/Factories/ResponseFactory.cs
@@ -38,7 +38,6 @@ namespace EvidenceApi.V1.Factories
             this DocumentSubmission domain,
             DocumentType documentType,
             DocumentType? staffSelectedDocumentType = null,
-            S3UploadPolicy? s3UploadPolicy = null,
             Document? document = null
         )
         {
@@ -51,7 +50,6 @@ namespace EvidenceApi.V1.Factories
                 State = domain.State.ToString().ToUpper(),
                 DocumentType = documentType,
                 StaffSelectedDocumentType = staffSelectedDocumentType,
-                UploadPolicy = s3UploadPolicy,
                 Document = document
             };
         }

--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -71,6 +71,22 @@ namespace EvidenceApi.V1.Gateways
             return await DeserializeResponse<S3UploadPolicy>(response).ConfigureAwait(true);
         }
 
+        public async Task UploadDocument(Guid documentId, DocumentSubmissionRequest request)
+        {
+            var uri = new Uri($"api/v1/documents/{documentId}", UriKind.Relative);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiPostDocumentsToken);
+            MultipartFormDataContent formDataContent = new MultipartFormDataContent();
+            var document = request.Document;
+            formDataContent.Headers.ContentType.MediaType = "multipart/form-data";
+            formDataContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("document");
+            formDataContent.Add(new StreamContent(document.OpenReadStream()), document.Name, document.FileName);
+            var response = await _client.PostAsync(uri, formDataContent).ConfigureAwait(true);
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw new DocumentsApiException($"Incorrect status code returned: {response.StatusCode}");
+            }
+        }
+
         public async Task<Claim> GetClaimById(string id)
         {
             var uri = new Uri($"api/v1/claims/{id}", UriKind.Relative);

--- a/EvidenceApi/V1/Gateways/Interfaces/IDocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IDocumentsApiGateway.cs
@@ -10,6 +10,7 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         Task<Claim> CreateClaim(ClaimRequest request);
         Task<Claim> UpdateClaim(Guid id, ClaimUpdateRequest request);
         Task<S3UploadPolicy> CreateUploadPolicy(Guid id);
+        Task UploadDocument(Guid documentId, DocumentSubmissionRequest request);
         Task<Claim> GetClaimById(string id);
     }
 }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -45,14 +45,13 @@ namespace EvidenceApi.V1.UseCase
             {
                 var claimRequest = BuildClaimRequest(evidenceRequest);
                 var claim = await _documentsApiGateway.CreateClaim(claimRequest).ConfigureAwait(true);
-                var createdS3UploadPolicy = await _documentsApiGateway.CreateUploadPolicy(claim.Document.Id).ConfigureAwait(true);
 
                 var documentSubmission = BuildDocumentSubmission(evidenceRequest, request, claim);
                 var createdDocumentSubmission = _evidenceGateway.CreateDocumentSubmission(documentSubmission);
 
                 var documentType = _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(evidenceRequest.Team, documentSubmission.DocumentTypeId);
 
-                return createdDocumentSubmission.ToResponse(documentType, null, createdS3UploadPolicy);
+                return createdDocumentSubmission.ToResponse(documentType);
             }
             catch (DocumentsApiException ex)
             {

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -94,6 +94,10 @@ namespace EvidenceApi.V1.UseCase
             {
                 throw new BadRequestException("Document type is null or empty");
             }
+            if (request.Document == null)
+            {
+                throw new BadRequestException("Document is null");
+            }
         }
     }
 }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -83,7 +83,8 @@ namespace EvidenceApi.V1.UseCase
             {
                 EvidenceRequest = evidenceRequest,
                 DocumentTypeId = request.DocumentType,
-                ClaimId = claim.Id.ToString()
+                ClaimId = claim.Id.ToString(),
+                State = SubmissionState.Uploaded
             };
             return documentSubmission;
         }

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionByIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionByIdUseCase.cs
@@ -45,7 +45,7 @@ namespace EvidenceApi.V1.UseCase
             try
             {
                 var claim = await _documentsApiGateway.GetClaimById(found.ClaimId).ConfigureAwait(true);
-                return found.ToResponse(documentType, staffSelectedDocumentType, null, claim.Document);
+                return found.ToResponse(documentType, staffSelectedDocumentType, claim.Document);
             }
             catch (DocumentsApiException ex)
             {

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -54,7 +54,7 @@ namespace EvidenceApi.V1.UseCase
                     }
                     else
                     {
-                        result.Add(ds.ToResponse(documentType, staffSelectedDocumentType, null, claim.Document));
+                        result.Add(ds.ToResponse(documentType, staffSelectedDocumentType, claim.Document));
                     }
                 }
             }

--- a/EvidenceApi/V1/UseCase/Interfaces/ICreateDocumentSubmission.cs
+++ b/EvidenceApi/V1/UseCase/Interfaces/ICreateDocumentSubmission.cs
@@ -7,6 +7,6 @@ namespace EvidenceApi.V1.UseCase.Interfaces
 {
     public interface ICreateDocumentSubmissionUseCase
     {
-        Task<DocumentSubmissionResponse> ExecuteAsync(Guid evidenceRequestId, DocumentSubmissionRequest request);
+        Task<DocumentSubmissionResponse> ExecuteAsync(DocumentSubmissionRequest request);
     }
 }


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-309

- The document is now provided when we create the Document Submission
- This is sent to DocumentsApi to be uploaded. PR for that - LBHackney-IT/documents-api/pull/86
- Document Submission is in _uploaded_ state
- This supersedes #85 which had wip code