### PR TITLE
Fix ssm parameters by removing ~true

### DIFF
--- a/EvidenceApi/serverless.yml
+++ b/EvidenceApi/serverless.yml
@@ -25,13 +25,13 @@ functions:
     handler: EvidenceApi::EvidenceApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
     environment:
-      CONNECTION_STRING: Host=${ssm:/evidence-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/evidence-api/${self:provider.stage}/postgres-port};Database=${ssm:/evidence-api/${self:provider.stage}/postgres-database};Username=${ssm:/evidence-api/${self:provider.stage}/postgres-username};Password=${ssm:/evidence-api/${self:provider.stage}/postgres-password~true}
+      CONNECTION_STRING: Host=${ssm:/evidence-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/evidence-api/${self:provider.stage}/postgres-port};Database=${ssm:/evidence-api/${self:provider.stage}/postgres-database};Username=${ssm:/evidence-api/${self:provider.stage}/postgres-username};Password=${ssm:/evidence-api/${self:provider.stage}/postgres-password}
       DOCUMENTS_API_URL: ${ssm:/documents-api/${self:provider.stage}/base-url}
       DOCUMENTS_API_GET_CLAIMS_TOKEN: ${ssm:/documents-api/${self:provider.stage}/get/claims/token}
       DOCUMENTS_API_POST_CLAIMS_TOKEN: ${ssm:/documents-api/${self:provider.stage}/post/claims/token}
       DOCUMENTS_API_PATCH_CLAIMS_TOKEN: ${ssm:/documents-api/${self:provider.stage}/patch/claims/token}
       DOCUMENTS_API_POST_DOCUMENTS_TOKEN: ${ssm:/documents-api/${self:provider.stage}/post/documents/token}
-      NOTIFY_API_KEY: ${ssm:/evidence-api/${self:provider.stage}/notify-api-key~true}
+      NOTIFY_API_KEY: ${ssm:/evidence-api/${self:provider.stage}/notify-api-key}
       NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_EMAIL: ${ssm:/evidence-api/notify/email/evidence-requested}
       NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_SMS: ${ssm:/evidence-api/notify/sms/evidence-requested}
       NOTIFY_TEMPLATE_EVIDENCE_REJECTED_EMAIL: ${ssm:/evidence-api/notify/email/evidence-rejected}


### PR DESCRIPTION
Removed ~true from the SSM parameters based on the guidance received in the warning of the previous CircleCI build