### PR TITLE
Doc 536

### DIFF
--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -48,14 +48,14 @@ namespace EvidenceApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void ThrowsBadRequestExceptionWhenBase64DocumentIsEmptyOrNull() 
+        public void ThrowsBadRequestExceptionWhenBase64DocumentIsEmptyOrNull()
         {
             var documentSubmissionRequest = _fixture.Build<DocumentSubmissionRequest>()
                 .Without(x => x.Base64Document)
                 .Create();
 
             Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
-            testDelegate.Should().Throw<BadRequestException>().WithMessage("Base 64 document is null or empty"); 
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("Base 64 document is null or empty");
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .Create();
 
             Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
-            testDelegate.Should().Throw<BadRequestException>().WithMessage("Base64 mime type is not accepted"); 
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("Base64 mime type is not accepted");
         }
 
         [Test]

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -48,6 +48,17 @@ namespace EvidenceApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void ThrowsBadRequestExceptionWhenBase64DocumentIsEmptyOrNull() 
+        {
+            var documentSubmissionRequest = _fixture.Build<DocumentSubmissionRequest>()
+                .Without(x => x.Base64Document)
+                .Create();
+
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
+            testDelegate.Should().Throw<BadRequestException>(); 
+        }
+
+        [Test]
         public void ThrowsNotFoundExceptionWhenEvidenceRequestIsNull()
         {
             var request = _fixture.Build<DocumentSubmissionRequest>()

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -70,6 +70,17 @@ namespace EvidenceApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void DoesNotThrowBadRequestExceptionWhenBase64DocumentIsAcceptedMimeType()
+        {
+            var documentSubmissionRequest = _fixture.Build<DocumentSubmissionRequest>()
+                .With(x => x.Base64Document, "data:application/pdf;")
+                .Create();
+
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
+            testDelegate.Should().NotThrow<BadRequestException>();
+        }
+
+        [Test]
         public void ThrowsNotFoundExceptionWhenEvidenceRequestIsNull()
         {
             var request = _fixture.Build<DocumentSubmissionRequest>()

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -44,7 +44,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .Without(x => x.DocumentType)
                 .Create();
             Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
-            testDelegate.Should().Throw<BadRequestException>();
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("Document type is null or empty");
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .Create();
 
             Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
-            testDelegate.Should().Throw<BadRequestException>(); 
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("Base 64 document is null or empty"); 
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .Create();
 
             Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
-            testDelegate.Should().Throw<BadRequestException>(); 
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("Base64 mime type is not accepted"); 
         }
 
         [Test]

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -59,6 +59,17 @@ namespace EvidenceApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void ThrowsBadRequestExceptionWhenBase64DocumentIsNotAcceptedMimeType()
+        {
+            var documentSubmissionRequest = _fixture.Build<DocumentSubmissionRequest>()
+                .With(x => x.Base64Document, "data:image/svg+xml;")
+                .Create();
+
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
+            testDelegate.Should().Throw<BadRequestException>(); 
+        }
+
+        [Test]
         public void ThrowsNotFoundExceptionWhenEvidenceRequestIsNull()
         {
             var request = _fixture.Build<DocumentSubmissionRequest>()


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-536

## Describe this PR

### *What is the problem we're trying to solve*

This commit continues the work that we did to solve the mime types check in the API. It adds tests to double check the functionality of the Validator method.

### *What changes have we introduced*

Added tests to check if base64 document is null, has unacceptable mime type and acceptable mimetype

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
