### PR TITLE
Add note_to_resident parameter to the request evidence template

### DIFF
--- a/EvidenceApi.Tests/TestDataHelper.cs
+++ b/EvidenceApi.Tests/TestDataHelper.cs
@@ -19,6 +19,7 @@ namespace EvidenceApi.Tests
                 .With(x => x.DocumentSubmissions, new List<DocumentSubmission>())
                 .With(x => x.RawDeliveryMethods, new List<string>())
                 .With(x => x.Team)
+                .With(x => x.NoteToResident)
                 .Create();
         }
 

--- a/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
@@ -49,7 +49,8 @@ namespace EvidenceApi.Tests.V1.Gateways
             {
                 {"resident_name", resident.Name},
                 {"reason", request.Reason},
-                {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{request.Id}"}
+                {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{request.Id}"},
+                {"note_to_resident", request.NoteToResident}
             };
 
             var response = _fixture.Create<SmsNotificationResponse>();
@@ -76,7 +77,8 @@ namespace EvidenceApi.Tests.V1.Gateways
             {
                 {"resident_name", resident.Name},
                 {"reason", request.Reason},
-                {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{request.Id}"}
+                {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{request.Id}"},
+                {"note_to_resident", request.NoteToResident}
             };
 
             var response = _fixture.Create<EmailNotificationResponse>();

--- a/EvidenceApi/V1/Gateways/NotifyGateway.cs
+++ b/EvidenceApi/V1/Gateways/NotifyGateway.cs
@@ -127,7 +127,8 @@ namespace EvidenceApi.V1.Gateways
                 {
                     {"resident_name", resident.Name},
                     {"reason", evidenceRequest.Reason},
-                    {"magic_link", MagicLinkFor(evidenceRequest)}
+                    {"magic_link", MagicLinkFor(evidenceRequest)},
+                    {"note_to_resident", evidenceRequest.NoteToResident}
                 },
                 _ => throw new ArgumentOutOfRangeException(nameof(communicationReason), communicationReason, $"Communication Reason {communicationReason.ToString()} not recognised")
             };

--- a/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
@@ -92,7 +92,7 @@ namespace EvidenceApi.V1.UseCase
                 NotificationEmail = request.NotificationEmail,
                 ResidentId = residentId,
                 ResidentReferenceId = residentReferenceId,
-                NoteToResident = request.NoteToResident
+                NoteToResident = String.IsNullOrEmpty(request.NoteToResident) ? "There is no additional information" : request.NoteToResident
             };
         }
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-682

## Describe this PR

This PR should only be merged when the entire feature is ready to be released to production! Once released to production the `Request for evidence` GOV Notify template for both email and sms should be updated based on `Request for evidence (test)` template. This update should be done ASAP after releasing to production to reduce the time the template doesn't match the backend.

### *What changes have we introduced*

- Added new parameter `note_to_resident` to the list of parameters to be used by GOV Notify template `Request for evidence`
- Updated the helper method that creates an evidence request in `CreateEvidenceRequestUseCase` to set a default value for `NoteToResident` when it's empty
- Updated test helper method to create an evidence request that contains a value for `NoteToResident` attribute
- Updated tests

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
