### PR TITLE
Add onboarding information for tenancy and leaseholds team

### DIFF
--- a/EvidenceApi/DocumentTypes.json
+++ b/EvidenceApi/DocumentTypes.json
@@ -155,5 +155,61 @@
         "description": "This is for internal use only to upload documents"
       }
     ]
+  },
+  {
+    "name": "Property Sales Team",
+    "id": "8",
+    "documentTypes": [
+      {
+        "id": "proof-of-id",
+        "title": "Proof of ID",
+        "description": "A valid document that can be used to prove identity"
+      },
+      {
+        "id": "proof-of-tenancy",
+        "title": "Proof of tenancy",
+        "description": "Photo of both sides of valid tenancy agreement for your home including signatures"
+      },
+      {
+        "id": "previous-tenancy-confirmation",
+        "title": "Previous tenancy confirmation",
+        "description": "If you have completed previous tenancy details on page 5 of the RTB1, please supply and tenancy agreements or relevant confirmation of tenancy."
+      },
+      {
+        "id": "proof-of-nationality",
+        "title": "Proof of nationality",
+        "description": "A valid document that can be used to prove nationality. IMPORTANT: If you are an overseas national you also need to provide us with proof of your entitlement to reside in the UK, ie you must have indefinite leave to remain."
+      },
+      {
+        "id": "proof-of-rtb",
+        "title": "Proof of previous Right to Buy discount",
+        "description": "If you have previously purchased a property under Right to Buy and completed Part D of the RTB1, please supply any relevant documentation."
+      },
+      {
+        "id": "opt-out-rtb",
+        "title": "Joint tenant opting out of the Right to Buy",
+        "description": "Upload of completed document"
+      },
+      {
+        "id": "proof-of-marriage",
+        "title": "Proof of marriage",
+        "description": "A valid document that can be used to prove marriage. If you are a tenant applying with a family member to whom you are married please supply a copy of the marriage certificate. Photo of whole document must be readable."
+      },
+      {
+        "id": "proof-of-address",
+        "title": "Proof of address",
+        "description": "A valid document to confirm residency"
+      },
+      {
+        "id": "give-up-permissions",
+        "title": "Confirmation to give up permissions",
+        "description": "All sections must be completed in full and signed by all applicants. Photo of all pages of the booklet"
+      },
+      {
+        "id": "anti-money-laundering",
+        "title": "Anti Money Laundering form",
+        "description": "All sections and additional information must be provided and signed by all applicants, photo of all pages of the booklet"
+      }
+    ]
   }
 ]

--- a/EvidenceApi/DocumentTypes.json
+++ b/EvidenceApi/DocumentTypes.json
@@ -157,7 +157,7 @@
     ]
   },
   {
-    "name": "Property Sales Team",
+    "name": "Leasehold and Right to Buy",
     "id": "8",
     "documentTypes": [
       {

--- a/EvidenceApi/StaffSelectedDocumentTypes.json
+++ b/EvidenceApi/StaffSelectedDocumentTypes.json
@@ -437,7 +437,7 @@
     ]
   },
   {
-    "name": "Property Sales Team",
+    "name": "Leasehold and Right to Buy",
     "id": "8",
     "documentTypes": [
       {
@@ -468,17 +468,47 @@
       {
         "id": "proof-of-tenancy-agreement",
         "title": "Proof of tenancy agreement",
-        "description": "Photo of both sides of valid tenancy agreement for your home including signatures"
+        "description": "Photo of both sides of valid tenancy agreement for the resident's home including signatures"
       },
       {
         "id": "certificate-of-naturalisation",
         "title": "Certificate of naturalisation",
-        "description": "Photo side (front)"
+        "description": "Photo side (front). IMPORTANT: If the resident is an overseas national they also need to provide us with proof of their entitlement to reside in the UK, ie they must have indefinite leave to remain."
       },
       {
         "id": "proof-of-rtb",
         "title": "Proof of previous Right to Buy discount",
-        "description": "If you have previously purchased a property under Right to Buy and completed Part D of the RTB1, please supply any relevant documentation. (add website link to form)"
+        "description": "If they have previously purchased a property under Right to Buy and completed Part D of the RTB1, resident to supply any relevant documentation. (website link to form)"
+      },
+      {
+        "id": "opt-out-rtb",
+        "title": "Joint tenant opting out of the Right to Buy",
+        "description": "Upload of completed document (website link to download)"
+      },
+      {
+        "id": "proof-of-marriage",
+        "title": "Proof of marriage",
+        "description": "A valid document that can be used to prove marriage. If the tenant is applying with a family member, supply a copy of the marriage certificate. Photo of whole document must be readable."
+      },
+      {
+        "id": "bank-statement",
+        "title": "Bank statement",
+        "description": "Valid from the last 3, 6 or 12 months"
+      },
+      {
+        "id": "utility-bill",
+        "title": "Utility bills",
+        "description": "Valid from the last 3, 6 or 12 months. For all utility bills - provide at least THREE of the following: All the documents you provide must show this information or we won’t be able to accept them: Applicants name (matching what’s shown on the RTB application)/Address/Date of the document (not just the dates that a document may cover). We cannot accept hand-written letters, undated documents or junk mail as sufficient evidence of where you live and how long you have lived there. Neither can we accept documents sent to you by Hackney Council or Hackney Homes. Documents must be from more than one organisation or company.  Please remember that one of the documents you provide must have a date from at least twelve months ago and one must be recent."
+      },
+      {
+        "id": "council-tax-bill",
+        "title": "Council tax bill",
+        "description": "Current financial year"
+      },
+      {
+        "id": "government-letter",
+        "title": "Government letter",
+        "description": "For example, benefit status letters"
       }
     ]
   }

--- a/EvidenceApi/StaffSelectedDocumentTypes.json
+++ b/EvidenceApi/StaffSelectedDocumentTypes.json
@@ -488,7 +488,7 @@
       {
         "id": "marriage-certificate",
         "title": "Marriage certificate",
-        "description": "If the tenant applying with a family member, please supply a copy of the marriage certificate. Photo of whole document readable."
+        "description": "A valid document that can be used to prove marriage. If the tenant is applying with a family member, supply a copy of the marriage certificate. Photo of whole document must be readable."
       },
       {
         "id": "bank-statement",

--- a/EvidenceApi/StaffSelectedDocumentTypes.json
+++ b/EvidenceApi/StaffSelectedDocumentTypes.json
@@ -435,5 +435,51 @@
         "description": ""
       }
     ]
+  },
+  {
+    "name": "Property Sales Team",
+    "id": "8",
+    "documentTypes": [
+      {
+        "id": "passport-scan",
+        "title": "Passport",
+        "description": "Data page with photo"
+      },
+      {
+        "id": "drivers-licence",
+        "title": "UK Drivers licence",
+        "description": "Photo side (front)"
+      },
+      {
+        "id": "eu-identity-card",
+        "title": "EU identity card",
+        "description": "Photo page"
+      },
+      {
+        "id": "biometric-card",
+        "title": "Biometric card",
+        "description": "Both sides of the card"
+      },
+      {
+        "id": "birth-certificate",
+        "title": "Birth certificate",
+        "description": "Photo side (front)"
+      },
+      {
+        "id": "proof-of-tenancy-agreement",
+        "title": "Proof of tenancy agreement",
+        "description": "Photo of both sides of valid tenancy agreement for your home including signatures"
+      },
+      {
+        "id": "certificate-of-naturalisation",
+        "title": "Certificate of naturalisation",
+        "description": "Photo side (front)"
+      },
+      {
+        "id": "proof-of-rtb",
+        "title": "Proof of previous Right to Buy discount",
+        "description": "If you have previously purchased a property under Right to Buy and completed Part D of the RTB1, please supply any relevant documentation. (add website link to form)"
+      }
+    ]
   }
 ]

--- a/EvidenceApi/StaffSelectedDocumentTypes.json
+++ b/EvidenceApi/StaffSelectedDocumentTypes.json
@@ -486,9 +486,9 @@
         "description": "Upload of completed document (website link to download)"
       },
       {
-        "id": "proof-of-marriage",
-        "title": "Proof of marriage",
-        "description": "A valid document that can be used to prove marriage. If the tenant is applying with a family member, supply a copy of the marriage certificate. Photo of whole document must be readable."
+        "id": "marriage-certificate",
+        "title": "Marriage certificate",
+        "description": "If the tenant applying with a family member, please supply a copy of the marriage certificate. Photo of whole document readable."
       },
       {
         "id": "bank-statement",
@@ -509,6 +509,16 @@
         "id": "government-letter",
         "title": "Government letter",
         "description": "For example, benefit status letters"
+      },
+      {
+        "id": "permission-booklet",
+        "title": "Permission booklet",
+        "description": "Photo of all pages of the booklet (Add link to form online)"
+      },
+      {
+        "id": "anti-money-laundering",
+        "title": "Anti Money Laundering form",
+        "description": "All sections and additional information must be provided and signed by all applicants, photo of all pages of the booklet"
       }
     ]
   }


### PR DESCRIPTION
## Describe this PR

Linked to this ticket: https://hackney.atlassian.net/browse/DOC-564

### *What changes have we introduced*

Added onboarding information for Tenancy and Leaseholds team. 

> Finished adding the config!)

Please check with Lewis the team name before merging. 

> They would like to be called Leasehold and Right to Buy

Also, this PR should be merged at the same time as the PR containing the onboarding information in the frontend.

> PR for the frontend exists -- being reviewed.

