### PR TITLE
Change config for Leasehold and Right to Buy to make docs more specific

### DIFF
--- a/EvidenceApi/DocumentTypes.json
+++ b/EvidenceApi/DocumentTypes.json
@@ -161,54 +161,89 @@
     "id": "8",
     "documentTypes": [
       {
-        "id": "proof-of-id",
-        "title": "Proof of ID",
-        "description": "A valid document that can be used to prove identity"
+        "id": "passport-scan",
+        "title": "Passport",
+        "description": "Data page with photo"
       },
       {
-        "id": "proof-of-tenancy",
-        "title": "Proof of tenancy",
+        "id": "drivers-licence",
+        "title": "UK Drivers licence",
+        "description": "Photo side (front)"
+      },
+      {
+        "id": "eu-identity-card",
+        "title": "EU identity card",
+        "description": "Photo page"
+      },
+      {
+        "id": "biometric-card",
+        "title": "Biometric card",
+        "description": "Both sides of the card"
+      },
+      {
+        "id": "birth-certificate",
+        "title": "Birth certificate",
+        "description": "Photo side (front)"
+      },
+      {
+        "id": "proof-of-tenancy-agreement",
+        "title": "Proof of tenancy agreement",
         "description": "Photo of both sides of valid tenancy agreement for your home including signatures"
       },
       {
-        "id": "previous-tenancy-confirmation",
-        "title": "Previous tenancy confirmation",
+        "id": "previous-tenancy-agreement",
+        "title": "Previous Tenancy Agreement",
         "description": "If you have completed previous tenancy details on page 5 of the RTB1, please supply and tenancy agreements or relevant confirmation of tenancy."
       },
       {
-        "id": "proof-of-nationality",
-        "title": "Proof of nationality",
-        "description": "A valid document that can be used to prove nationality. IMPORTANT: If you are an overseas national you also need to provide us with proof of your entitlement to reside in the UK, ie you must have indefinite leave to remain."
+        "id": "certificate-of-naturalisation",
+        "title": "Certificate of naturalisation",
+        "description": "Photo side (front). IMPORTANT: If you are an overseas national you also need to provide us with proof of your entitlement to reside in the UK, ie you must have indefinite leave to remain."
       },
       {
         "id": "proof-of-rtb",
         "title": "Proof of previous Right to Buy discount",
-        "description": "If you have previously purchased a property under Right to Buy and completed Part D of the RTB1, please supply any relevant documentation."
+        "description": "If you have previously purchased a property under Right to Buy and completed Part D of the RTB1, you need to supply any relevant documentation (add website link to form)"
       },
       {
         "id": "opt-out-rtb",
         "title": "Joint tenant opting out of the Right to Buy",
-        "description": "Upload of completed document"
+        "description": "Upload of completed document (add website link to download)"
       },
       {
-        "id": "proof-of-marriage",
-        "title": "Proof of marriage",
-        "description": "A valid document that can be used to prove marriage. If you are a tenant applying with a family member to whom you are married please supply a copy of the marriage certificate. Photo of whole document must be readable."
+        "id": "marriage-certificate",
+        "title": "Marriage certificate",
+        "description": "A valid document that can be used to prove marriage. If you are applying with a family member to whom you are married, supply a copy of the marriage certificate. Photo of whole document must be readable."
       },
       {
-        "id": "proof-of-address",
-        "title": "Proof of address",
-        "description": "A valid document to confirm residency"
+        "id": "bank-statement",
+        "title": "Bank statement",
+        "description": "Valid from the last 3, 6 or 12 months"
       },
       {
-        "id": "give-up-permissions",
-        "title": "Confirmation to give up permissions",
-        "description": "All sections must be completed in full and signed by all applicants. Photo of all pages of the booklet"
+        "id": "utility-bill",
+        "title": "Utility bills",
+        "description": "Valid from the last 3, 6 or 12 months. For all utility bills - provide at least THREE of the following: All the documents you provide must show this information or we won’t be able to accept them: Applicants name (matching what’s shown on the RTB application)/Address/Date of the document (not just the dates that a document may cover). We cannot accept hand-written letters, undated documents or junk mail as sufficient evidence of where you live and how long you have lived there. Neither can we accept documents sent to you by Hackney Council or Hackney Homes. Documents must be from more than one organisation or company.  Please remember that one of the documents you provide must have a date from at least twelve months ago and one must be recent."
+      },
+      {
+        "id": "council-tax-bill",
+        "title": "Council tax bill",
+        "description": "Current financial year"
+      },
+      {
+        "id": "government-letter",
+        "title": "Government letter",
+        "description": "For example, benefit status letters"
+      },
+      {
+        "id": "permission-booklet",
+        "title": "Permission booklet",
+        "description": "All sections must be completed in full and signed by all applicants. Photo of all pages of the booklet (Add link to form online)"
       },
       {
         "id": "anti-money-laundering",
         "title": "Anti Money Laundering form",
-        "description": "All sections and additional information must be provided and signed by all applicants, photo of all pages of the booklet"
+        "description": "All sections and additional information must be provided and signed by all applicants, photo of all pages of the booklet (add link to online form)"
       }
     ]
   },

--- a/EvidenceApi/StaffSelectedDocumentTypes.json
+++ b/EvidenceApi/StaffSelectedDocumentTypes.json
@@ -471,6 +471,11 @@
         "description": "Photo of both sides of valid tenancy agreement for the resident's home including signatures"
       },
       {
+        "id": "previous-tenancy-agreement",
+        "title": "Previous Tenancy Agreement",
+        "description": "If you have completed previous tenancy details on page 5 of the RTB1, please supply and tenancy agreements or relevant confirmation of tenancy."
+      },
+      {
         "id": "certificate-of-naturalisation",
         "title": "Certificate of naturalisation",
         "description": "Photo side (front). IMPORTANT: If the resident is an overseas national they also need to provide us with proof of their entitlement to reside in the UK, ie they must have indefinite leave to remain."


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-810

## Describe this PR

### *What is the problem we're trying to solve*

As part of their onboarding, Leasehold and Right to Buy have requested that we change their config to make the requested documents more specific i.e. not 'proof of id', but 'passport'. This commit makes those specific types available, but officers will still need to confirm another time what type they are when they go to approve the document.

### *What changes have we introduced*

Replaced the previous document types with new ones. This requires a wipe of all Leasehold and Right to Buy evidence requests in staging, as missing ids from previous evidence requests (e.g. proof-of-id) will cause the request page to crash.

For ref, the onboarding info can be found here: https://docs.google.com/spreadsheets/d/1x0lurLL9n_NgxE-Z4-SSjYRf0ixfBreDkIy6EGN7T3M/edit#gid=482343803

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check that staging works once the data has been wiped.
