### PR TITLE
Fix EvidenceRequest state change bug

### DIFF
--- a/EvidenceApi.Tests/V1/UseCase/UpdateEvidenceRequestStateUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/UpdateEvidenceRequestStateUseCaseTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using EvidenceApi.V1.Domain;
 using EvidenceApi.V1.Gateways.Interfaces;
 using FluentAssertions;
@@ -27,7 +28,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         public void ReturnsTheUpdatedEvidenceRequestWhenStateIsApproved()
         {
             var id = Guid.NewGuid();
-            SetupMocks();
+            SetupMocks("approved");
             EvidenceRequestApprovedState(_found);
             var result = _classUnderTest.Execute(id);
 
@@ -39,7 +40,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         public void ReturnsTheUpdatedEvidenceRequestWhenStateIsForReview()
         {
             var id = Guid.NewGuid();
-            SetupMocks();
+            SetupMocks("for review");
             EvidenceRequestForReviewState(_found);
             var result = _classUnderTest.Execute(id);
 
@@ -51,7 +52,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         public void ReturnsTheUpdatedEvidenceRequestWhenStateIsPending()
         {
             var id = Guid.NewGuid();
-            SetupMocks();
+            SetupMocks("pending");
             EvidenceRequestForPendingState(_found);
             var result = _classUnderTest.Execute(id);
 
@@ -73,11 +74,25 @@ namespace EvidenceApi.Tests.V1.UseCase
             _evidenceGateway.VerifyAll();
         }
 
-        private void SetupMocks()
+        private void SetupMocks(string state)
         {
             _found = TestDataHelper.EvidenceRequest();
 
+            switch(state)
+            {
+                case "approved":
+                    EvidenceRequestApprovedState(_found);
+                break;
+                case "for review":
+                    EvidenceRequestForReviewState(_found);
+                    break;
+                case "pending":
+                    EvidenceRequestForPendingState(_found);
+                    break;
+            }
+
             _evidenceGateway.Setup(x => x.FindEvidenceRequest(It.IsAny<Guid>())).Returns(_found);
+            _evidenceGateway.Setup(x => x.FindDocumentSubmissionsByEvidenceRequestId(It.IsAny<Guid>())).Returns(_found.DocumentSubmissions.ToList());
             _evidenceGateway.Setup(x => x.CreateEvidenceRequest(It.IsAny<EvidenceRequest>())).Returns(_found);
         }
 

--- a/EvidenceApi/V1/UseCase/UpdateEvidenceRequestStateUseCase.cs
+++ b/EvidenceApi/V1/UseCase/UpdateEvidenceRequestStateUseCase.cs
@@ -21,18 +21,22 @@ namespace EvidenceApi.V1.UseCase
         public EvidenceRequest Execute(Guid id)
         {
             var evidenceRequest = _evidenceGateway.FindEvidenceRequest(id);
+
             if (evidenceRequest == null)
             {
                 throw new NotFoundException($"Cannot find an evidence request with ID: {id}");
             }
 
-            if (allDocumentSubmissionsAreApproved(evidenceRequest))
+            var documentSubmissions = _evidenceGateway.FindDocumentSubmissionsByEvidenceRequestId(id);
+            evidenceRequest.DocumentSubmissions = documentSubmissions;
+
+            if (AllDocumentSubmissionsAreApproved(evidenceRequest))
             {
                 evidenceRequest.State = EvidenceRequestState.Approved;
             }
             else
             {
-                if (atLeastOneDocumentSubmissionisUploaded(evidenceRequest))
+                if (AtLeastOneDocumentSubmissionIsUploaded(evidenceRequest))
                 {
                     evidenceRequest.State = EvidenceRequestState.ForReview;
                 }
@@ -45,7 +49,7 @@ namespace EvidenceApi.V1.UseCase
             return evidenceRequest;
         }
 
-        private static bool allDocumentSubmissionsAreApproved(EvidenceRequest evidenceRequest)
+        private static bool AllDocumentSubmissionsAreApproved(EvidenceRequest evidenceRequest)
         {
             return evidenceRequest.DocumentTypes.ToArray().All(dt =>
                 evidenceRequest.DocumentSubmissions.Any(ds =>
@@ -53,7 +57,7 @@ namespace EvidenceApi.V1.UseCase
             );
         }
 
-        private static bool atLeastOneDocumentSubmissionisUploaded(EvidenceRequest evidenceRequest)
+        private static bool AtLeastOneDocumentSubmissionIsUploaded(EvidenceRequest evidenceRequest)
         {
             return evidenceRequest.DocumentTypes.ToArray().Any(dt =>
                 evidenceRequest.DocumentSubmissions.Any(ds =>


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-836

## Describe this PR

### *What is the problem we're trying to solve*

When working on https://hackney.atlassian.net/browse/DOC-809 we found that the filtering was not displaying all of the evidence requests that were pending. We found out that this is because the evidence request state was not updating when document submission states were changed.

### *What changes have we introduced*

We found out that when we call `.FindEvidenceRequest` in the use case, it would only return one DocumentSubmission. This would cause the logic to assume that the EvidenceRequest is still in 'Pending' and set it to that state.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

We will want to discuss whether we should update existing evidence requests in the staging and production databases to make the filter function work correctly, or keep it as is.
