### PR TITLE
Update serverless parameter names for gov notify templates

### DIFF
--- a/EvidenceApi/serverless.yml
+++ b/EvidenceApi/serverless.yml
@@ -33,11 +33,11 @@ functions:
       DOCUMENTS_API_POST_DOCUMENTS_TOKEN: ${ssm:/documents-api/${self:provider.stage}/post/documents/token}
       DOCUMENTS_API_GET_DOCUMENTS_TOKEN: ${ssm:/documents-api/${self:provider.stage}/get/documents/token}
       NOTIFY_API_KEY: ${ssm:/evidence-api/${self:provider.stage}/notify-api-key}
-      NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_EMAIL: ${ssm:/evidence-api/notify/email/evidence-requested}
-      NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_SMS: ${ssm:/evidence-api/notify/sms/evidence-requested}
-      NOTIFY_TEMPLATE_EVIDENCE_REJECTED_EMAIL: ${ssm:/evidence-api/notify/email/evidence-rejected}
-      NOTIFY_TEMPLATE_EVIDENCE_REJECTED_SMS: ${ssm:/evidence-api/notify/sms/evidence-rejected}
-      NOTIFY_TEMPLATE_DOCUMENT_UPLOADED_EMAIL: ${ssm:/evidence-api/notify/email/document-uploaded}
+      NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_EMAIL: ${ssm:/evidence-api/${self:provider.stage}/notify/email/evidence-requested}
+      NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_SMS: ${ssm:/evidence-api/${self:provider.stage}/notify/sms/evidence-requested}
+      NOTIFY_TEMPLATE_EVIDENCE_REJECTED_EMAIL: ${ssm:/evidence-api/${self:provider.stage}/notify/email/evidence-rejected}
+      NOTIFY_TEMPLATE_EVIDENCE_REJECTED_SMS: ${ssm:/evidence-api/${self:provider.stage}/notify/sms/evidence-rejected}
+      NOTIFY_TEMPLATE_DOCUMENT_UPLOADED_EMAIL: ${ssm:/evidence-api/${self:provider.stage}/notify/email/document-uploaded}
       EVIDENCE_REQUEST_CLIENT_URL: https://${ssm:/evidence-api/${self:provider.stage}/client-url}
     events:
       - http:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-843

## Describe this PR

### *What changes have we introduced*

Updated the names of the SSM parameters in serverless to include the name of the stage. This helps referencing the correct name for the template based on the stage.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
