### PR TITLE
Show what types of documents were requested in evidence request in first email to resident

### DIFF
--- a/EvidenceApi.Tests/TestDataHelper.cs
+++ b/EvidenceApi.Tests/TestDataHelper.cs
@@ -53,6 +53,18 @@ namespace EvidenceApi.Tests
             return reader.GetData().SelectMany(t => t.DocumentTypes).ToList().Find(dt => dt.Id == id);
         }
 
+        public static List<DocumentType> GetDistinctDocumentTypes()
+        {
+            var options = AppOptions.FromEnv();
+            var reader = new FileReader<List<Team>>(options.DocumentTypeConfigPath);
+
+
+            var listOfAllDocumentTypes = reader.GetData().SelectMany(team => team.DocumentTypes).ToList();
+            var distinctDocumentTypesById = listOfAllDocumentTypes.GroupBy(documentType => documentType.Id)
+                .Select(documentType => documentType.First()).ToList();
+            return distinctDocumentTypesById;
+        }
+
         public static DocumentType StaffSelectedDocumentType(string id)
         {
             var options = AppOptions.FromEnv();

--- a/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
@@ -46,7 +46,7 @@ namespace EvidenceApi.Tests.V1.Gateways
             request.Reason = "some-reason";
 
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
-            var formattedDocumentTypes = "Proof of ID,\nRepairs Photo";
+            var formattedDocumentTypes = "Proof of ID,\nRepairs photo";
             var expectedParams = new Dictionary<string, object>
             {
                 {"resident_name", resident.Name},
@@ -56,13 +56,8 @@ namespace EvidenceApi.Tests.V1.Gateways
                 {"document_types", formattedDocumentTypes}
             };
 
-            var documentTypesByTeamName = new List<DocumentType>
-            {
-                new DocumentType() {Id = "proof-of-id", Title = "Proof of ID", Description = ""},
-                new DocumentType() {Id = "repairs-photo", Title = "Repairs Photo", Description = ""}
-            };
             _documentTypeGateway.Setup(x => x.GetDocumentTypesByTeamName(It.IsAny<string>()))
-                .Returns(documentTypesByTeamName);
+                .Returns(TestDataHelper.GetDistinctDocumentTypes);
 
             var response = _fixture.Create<SmsNotificationResponse>();
             _notifyClient.SetReturnsDefault(response);
@@ -86,7 +81,7 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
 
-            var formattedDocumentTypes = "Proof of ID,\nRepairs Photo";
+            var formattedDocumentTypes = "Proof of ID,\nRepairs photo";
             var expectedParams = new Dictionary<string, object>
             {
                 {"resident_name", resident.Name},
@@ -96,13 +91,8 @@ namespace EvidenceApi.Tests.V1.Gateways
                 {"document_types", formattedDocumentTypes}
             };
 
-            var documentTypesByTeamName = new List<DocumentType>
-            {
-                new DocumentType() {Id = "proof-of-id", Title = "Proof of ID", Description = ""},
-                new DocumentType() {Id = "repairs-photo", Title = "Repairs Photo", Description = ""}
-            };
             _documentTypeGateway.Setup(x => x.GetDocumentTypesByTeamName(It.IsAny<string>()))
-                .Returns(documentTypesByTeamName);
+                .Returns(TestDataHelper.GetDistinctDocumentTypes);
 
             var response = _fixture.Create<EmailNotificationResponse>();
             _notifyClient.SetReturnsDefault(response);
@@ -213,13 +203,8 @@ namespace EvidenceApi.Tests.V1.Gateways
             var envVar = "NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_EMAIL";
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
 
-            var documentTypesByTeamName = new List<DocumentType>
-            {
-                new DocumentType() {Id = "proof-of-id", Title = "Proof of ID", Description = ""},
-                new DocumentType() {Id = "repairs-photo", Title = "Repairs Photo", Description = ""}
-            };
             _documentTypeGateway.Setup(x => x.GetDocumentTypesByTeamName(It.IsAny<string>()))
-                .Returns(documentTypesByTeamName);
+                .Returns(TestDataHelper.GetDistinctDocumentTypes);
 
             var response = _fixture.Create<EmailNotificationResponse>();
             _notifyClient.Setup(x =>

--- a/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
@@ -198,6 +198,7 @@ namespace EvidenceApi.Tests.V1.Gateways
             var resident = _fixture.Create<Resident>();
             var evidenceRequest = TestDataHelper.EvidenceRequest();
             evidenceRequest.ResidentId = resident.Id;
+            evidenceRequest.DocumentTypes = new List<string> { "proof-of-id", "repairs-photo" };
             evidenceRequest.Reason = "some-reason";
 
             var envVar = "NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_EMAIL";

--- a/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
@@ -41,24 +41,35 @@ namespace EvidenceApi.Tests.V1.Gateways
             var envVar = "NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_SMS";
             var resident = _fixture.Create<Resident>();
             var request = TestDataHelper.EvidenceRequest();
+            request.DocumentTypes = new List<string> { "proof-of-id", "repairs-photo" };
             request.ResidentId = resident.Id;
             request.Reason = "some-reason";
 
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
+            var formattedDocumentTypes = "Proof of ID,\nRepairs Photo";
             var expectedParams = new Dictionary<string, object>
             {
                 {"resident_name", resident.Name},
                 {"reason", request.Reason},
                 {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{request.Id}"},
-                {"note_to_resident", request.NoteToResident}
+                {"note_to_resident", request.NoteToResident},
+                {"document_types", formattedDocumentTypes}
             };
+
+            var documentTypesByTeamName = new List<DocumentType>
+            {
+                new DocumentType() {Id = "proof-of-id", Title = "Proof of ID", Description = ""},
+                new DocumentType() {Id = "repairs-photo", Title = "Repairs Photo", Description = ""}
+            };
+            _documentTypeGateway.Setup(x => x.GetDocumentTypesByTeamName(It.IsAny<string>()))
+                .Returns(documentTypesByTeamName);
 
             var response = _fixture.Create<SmsNotificationResponse>();
             _notifyClient.SetReturnsDefault(response);
             _classUnderTest.SendNotification(deliveryMethod, communicationReason, request, resident);
             _notifyClient.Verify(x =>
                 x.SendSms(resident.PhoneNumber, expectedTemplateId,
-                    It.Is<Dictionary<string, object>>(x => CompareDictionaries(expectedParams, x)), null, null));
+                    It.Is<Dictionary<string, object>>(x => CompareDictionaries(expectedParams, x)), null, null), Times.Once);
         }
 
         [Test]
@@ -201,6 +212,14 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             var envVar = "NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_EMAIL";
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
+
+            var documentTypesByTeamName = new List<DocumentType>
+            {
+                new DocumentType() {Id = "proof-of-id", Title = "Proof of ID", Description = ""},
+                new DocumentType() {Id = "repairs-photo", Title = "Repairs Photo", Description = ""}
+            };
+            _documentTypeGateway.Setup(x => x.GetDocumentTypesByTeamName(It.IsAny<string>()))
+                .Returns(documentTypesByTeamName);
 
             var response = _fixture.Create<EmailNotificationResponse>();
             _notifyClient.Setup(x =>

--- a/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/NotifyGatewayTests.cs
@@ -40,19 +40,19 @@ namespace EvidenceApi.Tests.V1.Gateways
             var communicationReason = CommunicationReason.EvidenceRequest;
             var envVar = "NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_SMS";
             var resident = _fixture.Create<Resident>();
-            var request = TestDataHelper.EvidenceRequest();
-            request.DocumentTypes = new List<string> { "proof-of-id", "repairs-photo" };
-            request.ResidentId = resident.Id;
-            request.Reason = "some-reason";
+            var evidenceRequest = TestDataHelper.EvidenceRequest();
+            evidenceRequest.DocumentTypes = new List<string> { "proof-of-id", "repairs-photo" };
+            evidenceRequest.ResidentId = resident.Id;
+            evidenceRequest.Reason = "some-reason";
 
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
             var formattedDocumentTypes = "Proof of ID,\nRepairs photo";
             var expectedParams = new Dictionary<string, object>
             {
                 {"resident_name", resident.Name},
-                {"reason", request.Reason},
-                {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{request.Id}"},
-                {"note_to_resident", request.NoteToResident},
+                {"reason", evidenceRequest.Reason},
+                {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{evidenceRequest.Id}"},
+                {"note_to_resident", evidenceRequest.NoteToResident},
                 {"document_types", formattedDocumentTypes}
             };
 
@@ -61,7 +61,7 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             var response = _fixture.Create<SmsNotificationResponse>();
             _notifyClient.SetReturnsDefault(response);
-            _classUnderTest.SendNotification(deliveryMethod, communicationReason, request, resident);
+            _classUnderTest.SendNotification(deliveryMethod, communicationReason, evidenceRequest, resident);
             _notifyClient.Verify(x =>
                 x.SendSms(resident.PhoneNumber, expectedTemplateId,
                     It.Is<Dictionary<string, object>>(x => CompareDictionaries(expectedParams, x)), null, null), Times.Once);
@@ -74,10 +74,10 @@ namespace EvidenceApi.Tests.V1.Gateways
             var communicationReason = CommunicationReason.EvidenceRequest;
             var envVar = "NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_EMAIL";
             var resident = _fixture.Create<Resident>();
-            var request = TestDataHelper.EvidenceRequest();
-            request.DocumentTypes = new List<string> { "proof-of-id", "repairs-photo" };
-            request.ResidentId = resident.Id;
-            request.Reason = "some-reason";
+            var evidenceRequest = TestDataHelper.EvidenceRequest();
+            evidenceRequest.DocumentTypes = new List<string> { "proof-of-id", "repairs-photo" };
+            evidenceRequest.ResidentId = resident.Id;
+            evidenceRequest.Reason = "some-reason";
 
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
 
@@ -85,9 +85,9 @@ namespace EvidenceApi.Tests.V1.Gateways
             var expectedParams = new Dictionary<string, object>
             {
                 {"resident_name", resident.Name},
-                {"reason", request.Reason},
-                {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{request.Id}"},
-                {"note_to_resident", request.NoteToResident},
+                {"reason", evidenceRequest.Reason},
+                {"magic_link", $"{_options.EvidenceRequestClientUrl}resident/{evidenceRequest.Id}"},
+                {"note_to_resident", evidenceRequest.NoteToResident},
                 {"document_types", formattedDocumentTypes}
             };
 
@@ -96,7 +96,7 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             var response = _fixture.Create<EmailNotificationResponse>();
             _notifyClient.SetReturnsDefault(response);
-            _classUnderTest.SendNotification(deliveryMethod, communicationReason, request, resident);
+            _classUnderTest.SendNotification(deliveryMethod, communicationReason, evidenceRequest, resident);
             _notifyClient.Verify(x =>
                     x.SendEmail(resident.Email, expectedTemplateId,
                         It.Is<Dictionary<string, object>>(x => CompareDictionaries(expectedParams, x)), null, null), Times.Once);
@@ -196,9 +196,9 @@ namespace EvidenceApi.Tests.V1.Gateways
             var deliveryMethod = DeliveryMethod.Email;
             var communicationReason = CommunicationReason.EvidenceRequest;
             var resident = _fixture.Create<Resident>();
-            var request = TestDataHelper.EvidenceRequest();
-            request.ResidentId = resident.Id;
-            request.Reason = "some-reason";
+            var evidenceRequest = TestDataHelper.EvidenceRequest();
+            evidenceRequest.ResidentId = resident.Id;
+            evidenceRequest.Reason = "some-reason";
 
             var envVar = "NOTIFY_TEMPLATE_EVIDENCE_REQUESTED_EMAIL";
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
@@ -212,7 +212,7 @@ namespace EvidenceApi.Tests.V1.Gateways
                         null))
                 .Returns(response);
 
-            _classUnderTest.SendNotification(deliveryMethod, communicationReason, request, resident);
+            _classUnderTest.SendNotification(deliveryMethod, communicationReason, evidenceRequest, resident);
 
             _evidenceGateway.Verify(x => x.CreateCommunication(It.Is<Communication>(x =>
                 x.Reason == communicationReason && x.DeliveryMethod == deliveryMethod && x.TemplateId == expectedTemplateId &&
@@ -224,22 +224,22 @@ namespace EvidenceApi.Tests.V1.Gateways
         {
             var deliveryMethod = DeliveryMethod.Email;
             var communicationReason = CommunicationReason.DocumentUploaded;
-            var request = TestDataHelper.EvidenceRequest();
+            var evidenceRequest = TestDataHelper.EvidenceRequest();
             var resident = TestDataHelper.Resident();
-            request.Reason = "some-reason";
-            request.NotificationEmail = "some@email";
-            request.ResidentId = resident.Id;
+            evidenceRequest.Reason = "some-reason";
+            evidenceRequest.NotificationEmail = "some@email";
+            evidenceRequest.ResidentId = resident.Id;
 
             var envVar = "NOTIFY_TEMPLATE_DOCUMENT_UPLOADED_EMAIL";
             var expectedTemplateId = Environment.GetEnvironmentVariable(envVar);
 
             var response = _fixture.Create<EmailNotificationResponse>();
             _notifyClient.Setup(x =>
-                    x.SendEmail(request.NotificationEmail, expectedTemplateId, It.IsAny<Dictionary<string, dynamic>>(), null,
+                    x.SendEmail(evidenceRequest.NotificationEmail, expectedTemplateId, It.IsAny<Dictionary<string, dynamic>>(), null,
                         null))
                 .Returns(response);
 
-            _classUnderTest.SendNotificationDocumentUploaded(deliveryMethod, communicationReason, request, resident);
+            _classUnderTest.SendNotificationDocumentUploaded(deliveryMethod, communicationReason, evidenceRequest, resident);
 
             _evidenceGateway.Verify(x => x.CreateCommunication(It.Is<Communication>(x =>
                 x.Reason == communicationReason && x.DeliveryMethod == deliveryMethod && x.TemplateId == expectedTemplateId &&

--- a/EvidenceApi/V1/Gateways/NotifyGateway.cs
+++ b/EvidenceApi/V1/Gateways/NotifyGateway.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EvidenceApi.V1.Domain;
 using EvidenceApi.V1.Domain.Enums;
 using EvidenceApi.V1.Gateways.Interfaces;
@@ -177,15 +178,8 @@ namespace EvidenceApi.V1.Gateways
         {
             var teamDocumentTypes = _documentTypeGateway.GetDocumentTypesByTeamName(evidenceRequest.Team);
             var evidenceRequestDocumentTypes = evidenceRequest.DocumentTypes;
-            var documentTypeTitles = new List<string>();
 
-            foreach (var documentType in teamDocumentTypes)
-            {
-                if (evidenceRequestDocumentTypes.Contains(documentType.Id))
-                {
-                    documentTypeTitles.Add(documentType.Title);
-                }
-            }
+            var documentTypeTitles = teamDocumentTypes.Where(tdt => evidenceRequestDocumentTypes.Contains(tdt.Id)).Select(dt => dt.Title);
 
             return string.Join(",\n", documentTypeTitles);
         }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-846

## Describe this PR

### *What is the problem we're trying to solve*

HR have identified that they would like the resident to be able to see what types of documents have been requested from them before they get onto the page where they need to upload the documents to DES. After discussion with the team, we decided that the place place to put this information (for now) is in the email.

### *What changes have we introduced*

As part of the evidence request creation, we request Gov Notify to send an email and SMS to the resident. As part of this request to Gov Notify, we send a dictionary of keys and data to display in the message template. I've added a new key called 'document_types' to include a string of all of the documentTypes that are part of the evidence request.

Here is what the old templates look like:
<img src="https://user-images.githubusercontent.com/56876663/174781327-b29dade6-3256-4336-918a-2b2ff087642f.png" alt="drawing" width="300"/>
<img src="https://user-images.githubusercontent.com/56876663/174781332-e3e78346-af48-4ccd-8606-3b27229de160.jpg" alt="drawing" width="300"/>

Here is what the new templates look like:
<img src="https://user-images.githubusercontent.com/56876663/174787137-150bfc91-778b-4bed-a0c8-8a3389467920.png" alt="drawing" width="300"/>
<img src="https://user-images.githubusercontent.com/56876663/174787168-f73e0785-cf8a-41a5-89fd-6ec09f3462ea.jpg" alt="drawing" width="300"/>


#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

I will need to add this new parameter into the Gov Notify template once this PR is approved. I will then test the functionality in staging.
