### PR TITLE
Add version specification to lock dotnet-ef to 6.0.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
             dpkg -i session-manager-plugin.deb
       - run:
           name: Install dotnet ef core
-          command: dotnet tool install dotnet-ef --tool-path ./dotnet-ef-local/
+          command: dotnet tool install dotnet-ef --version 6.0.5 --tool-path ./dotnet-ef-local/
       - run:
           name: SSH into RDS and migrate database
           command: |


### PR DESCRIPTION
## Link to JIRA ticket

No ticket!

## Describe this PR

### *What is the problem we're trying to solve*

CircleCI fails because the was a recent patch to dotnet-ef and our pipeline fails with this error:

![Screenshot 2022-06-17 at 16 18 51](https://user-images.githubusercontent.com/56876663/174328045-8be23e32-212b-479a-8ecb-f820d5de6984.png)


### *What changes have we introduced*

Update config to lock version to 6.0.5, the last working version for us.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
