### PR TITLE
Officer to receive one email per upload from resident

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -206,7 +206,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             string body = "{}";
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
             var uri = new Uri($"api/v1/evidence_requests/{entity.Id}/document_submissions", UriKind.Relative);
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
             response.StatusCode.Should().Be(400);
         }
 
@@ -238,7 +238,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var uri = new Uri($"api/v1/evidence_requests/{entity.Id}/document_submissions", UriKind.Relative);
 
             // Act
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
 
             // Assert
             response.StatusCode.Should().Be(400);
@@ -267,10 +267,10 @@ namespace EvidenceApi.Tests.V1.E2ETests
                           "}";
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
             var uri = new Uri($"api/v1/evidence_requests/{entity.Id}/document_submissions", UriKind.Relative);
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
             response.StatusCode.Should().Be(201);
 
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var json = await response.Content.ReadAsStringAsync();
 
             var created = DatabaseContext.DocumentSubmissions.First();
 
@@ -305,7 +305,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                           "}";
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
             var uri = new Uri($"api/v1/evidence_requests/{fakeId}/document_submissions", UriKind.Relative);
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
 
             response.StatusCode.Should().Be(404);
         }
@@ -345,7 +345,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
 
             // Act
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
 
             // Assert
             response.StatusCode.Should().Be(400);

--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -40,10 +40,10 @@ namespace EvidenceApi.Tests.V1.E2ETests
             }";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
             response.StatusCode.Should().Be(201);
 
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var json = await response.Content.ReadAsStringAsync();
             var created = DatabaseContext.EvidenceRequests.First();
             var resident = DatabaseContext.Residents.First();
 
@@ -93,7 +93,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             }";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
             response.StatusCode.Should().Be(400);
         }
 
@@ -114,7 +114,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             }";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, jsonString);
             response.StatusCode.Should().Be(400);
         }
 
@@ -136,8 +136,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             DatabaseContext.EvidenceRequests.Add(entity);
             DatabaseContext.SaveChanges();
             var uri = new Uri($"api/v1/evidence_requests/{entity.Id}", UriKind.Relative);
-            var responseFind = await Client.GetAsync(uri).ConfigureAwait(true);
-            var jsonFind = await responseFind.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var responseFind = await Client.GetAsync(uri);
+            var jsonFind = await responseFind.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<EvidenceRequestResponse>(jsonFind);
 
             var expectedDocumentType = TestDataHelper.DocumentType("passport-scan");
@@ -151,7 +151,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
         {
             var fakeId = "ed0f2bd2-df90-4f01-b7f1-d30e402386d0";
             var uri = new Uri($"api/v1/evidence_requests/{fakeId}", UriKind.Relative);
-            var responseFind = await Client.GetAsync(uri).ConfigureAwait(true);
+            var responseFind = await Client.GetAsync(uri);
             responseFind.StatusCode.Should().Be(404);
         }
 
@@ -161,8 +161,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var expected = BuildEvidenceRequestsListWithSameResident();
             var team = expected[0].Team;
             var uri = new Uri($"api/v1/evidence_requests?team={team}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
+            var json = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<List<EvidenceRequestResponse>>(json);
 
             response.StatusCode.Should().Be(200);
@@ -177,8 +177,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var team = expected[0].Team;
             var residentId = expected[0].Resident.Id;
             var uri = new Uri($"api/v1/evidence_requests?team={team}&residentId={residentId}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
+            var json = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<List<EvidenceRequestResponse>>(json);
 
             response.StatusCode.Should().Be(200);
@@ -192,8 +192,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var team = expected[0].Team;
             var residentId = expected[1].Resident.Id;
             var uri = new Uri($"api/v1/evidence_requests?team={team}&residentId={residentId}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
+            var json = await response.Content.ReadAsStringAsync();
             var result = JsonConvert.DeserializeObject<List<EvidenceRequestResponse>>(json);
 
             response.StatusCode.Should().Be(200);
@@ -205,7 +205,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
         {
             var team = "";
             var uri = new Uri($"api/v1/evidence_requests?team={team}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
 
             response.StatusCode.Should().Be(400);
         }
@@ -216,13 +216,13 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var team = "";
             var residentId = "";
             var uri = new Uri($"api/v1/evidence_requests?team={team}&residentId={residentId}", UriKind.Relative);
-            var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            var response = await Client.GetAsync(uri);
 
             response.StatusCode.Should().Be(400);
         }
 
         [Test]
-        public async Task CanSendANotificationUploadConfirmationToResident()
+        public async Task CanSendANotificationUploadConfirmationToResidentAndStaff()
         {
             var evidenceRequest = TestDataHelper.EvidenceRequest();
             var resident = TestDataHelper.Resident();
@@ -233,7 +233,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             DatabaseContext.EvidenceRequests.Add(evidenceRequest);
             DatabaseContext.SaveChanges();
             var uri = new Uri($"api/v1/evidence_requests/{evidenceRequest.Id}/confirmation", UriKind.Relative);
-            var response = await Client.PostAsync(uri, null).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, null);
 
             response.StatusCode.Should().Be(200);
         }
@@ -243,8 +243,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
         {
             var id = Guid.NewGuid();
             var uri = new Uri($"api/v1/evidence_requests/{id}/confirmation", UriKind.Relative);
-            var response = await Client.PostAsync(uri, null).ConfigureAwait(true);
-            var message = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, null);
+            var message = await response.Content.ReadAsStringAsync();
 
             response.StatusCode.Should().Be(404);
             message.Should().Contain($"Cannot find evidence request with id: {id}");
@@ -257,8 +257,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             DatabaseContext.EvidenceRequests.Add(evidenceRequest);
             DatabaseContext.SaveChanges();
             var uri = new Uri($"api/v1/evidence_requests/{evidenceRequest.Id}/confirmation", UriKind.Relative);
-            var response = await Client.PostAsync(uri, null).ConfigureAwait(true);
-            var message = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, null);
+            var message = await response.Content.ReadAsStringAsync();
 
             response.StatusCode.Should().Be(404);
             message.Should().Contain($"Cannot find resident with id: {evidenceRequest.ResidentId}");
@@ -282,7 +282,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                 x.SendEmail("", It.IsAny<string>(), It.IsAny<Dictionary<string, dynamic>>(), null, null)).Throws(new NotifyClientException());
 
             var uri = new Uri($"api/v1/evidence_requests/{evidenceRequest.Id}/confirmation", UriKind.Relative);
-            var response = await Client.PostAsync(uri, null).ConfigureAwait(true);
+            var response = await Client.PostAsync(uri, null);
             response.StatusCode.Should().Be(400);
         }
 

--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -14,12 +14,48 @@ using EvidenceApi.V1.Domain.Enums;
 using EvidenceApi.V1.Boundary.Response;
 using EvidenceApi.V1.Factories;
 using Notify.Exceptions;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
 
 namespace EvidenceApi.Tests.V1.E2ETests
 {
     public class EvidenceRequestsTest : IntegrationTests<Startup>
     {
         private readonly IFixture _fixture = new Fixture();
+        private Claim _createdClaim;
+        private Document _document;
+        private S3UploadPolicy _createdUploadPolicy;
+        private readonly Guid _id = Guid.NewGuid();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _document = _fixture.Build<Document>()
+                .With(x => x.Id, _id)
+                .Create();
+            _createdClaim = _fixture.Build<Claim>()
+                .With(x => x.Document, _document)
+                .Create();
+
+            _createdUploadPolicy = _fixture.Create<S3UploadPolicy>();
+
+            DocumentsApiServer.Given(
+                Request.Create().WithPath("/api/v1/claims")
+            ).RespondWith(
+                Response.Create().WithStatusCode(201).WithBody(
+                    JsonConvert.SerializeObject(_createdClaim)
+                )
+            );
+
+            DocumentsApiServer.Given(
+                Request.Create().WithPath($"/api/v1/documents/{_id}/upload_policies")
+            ).RespondWith(
+                Response.Create().WithStatusCode(200).WithBody(
+                    JsonConvert.SerializeObject(_createdUploadPolicy)
+                )
+            );
+        }
+
         [Test]
         public async Task CanCreateEvidenceRequestWithValidParams()
         {
@@ -155,6 +191,165 @@ namespace EvidenceApi.Tests.V1.E2ETests
             responseFind.StatusCode.Should().Be(404);
         }
 
+        [Test]
+        public async Task CreateDocumentSubmissionUnsuccessfulWhenNoDocumentTypeProvided()
+        {
+            var entity = _fixture.Build<EvidenceRequest>()
+                .With(x => x.DocumentTypes, new List<string> { "passport-scan" })
+                .With(x => x.DeliveryMethods, new List<DeliveryMethod> { DeliveryMethod.Email })
+                .Without(x => x.Communications)
+                .Without(x => x.DocumentSubmissions)
+                .Create();
+            DatabaseContext.EvidenceRequests.Add(entity);
+            DatabaseContext.SaveChanges();
+
+            string body = "{}";
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/evidence_requests/{entity.Id}/document_submissions", UriKind.Relative);
+            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(400);
+        }
+
+
+        [Test]
+        public async Task CreateDocumentSubmissionUnsuccessfulWhenCannotCreateClaim()
+        {
+            // Arrange
+            var entity = _fixture.Build<EvidenceRequest>()
+                .With(x => x.DocumentTypes, new List<string> { "passport-scan" })
+                .With(x => x.DeliveryMethods, new List<DeliveryMethod> { DeliveryMethod.Email })
+                .Without(x => x.Communications)
+                .Without(x => x.DocumentSubmissions)
+                .Create();
+            DatabaseContext.EvidenceRequests.Add(entity);
+            DatabaseContext.SaveChanges();
+
+            DocumentsApiServer.Reset();
+            DocumentsApiServer.Given(
+                Request.Create().WithPath("/api/v1/claims")
+            ).RespondWith(
+                Response.Create().WithStatusCode(404)
+            );
+
+            string body = "{" +
+                          "\"documentType\": \"proof-of-id\"" +
+                          "}";
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/evidence_requests/{entity.Id}/document_submissions", UriKind.Relative);
+
+            // Act
+            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+
+            // Assert
+            response.StatusCode.Should().Be(400);
+        }
+
+
+        [Test]
+        public async Task CanCreateDocumentSubmissionWithValidParams()
+        {
+            var resident = TestDataHelper.Resident();
+            resident.Id = Guid.NewGuid();
+            var entity = _fixture.Build<EvidenceRequest>()
+                .With(x => x.DocumentTypes, new List<string> { "proof-of-id" })
+                .With(x => x.DeliveryMethods, new List<DeliveryMethod> { DeliveryMethod.Email })
+                .With(x => x.Team, "Development Housing Team")
+                .Without(x => x.Communications)
+                .Without(x => x.DocumentSubmissions)
+                .Create();
+            entity.ResidentId = resident.Id;
+            DatabaseContext.Residents.Add(resident);
+            DatabaseContext.EvidenceRequests.Add(entity);
+            DatabaseContext.SaveChanges();
+
+            string body = "{" +
+                          "\"documentType\": \"proof-of-id\"" +
+                          "}";
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/evidence_requests/{entity.Id}/document_submissions", UriKind.Relative);
+            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(201);
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+
+            var created = DatabaseContext.DocumentSubmissions.First();
+
+            var formattedCreatedAt = JsonConvert.SerializeObject(created.CreatedAt);
+            var formattedValidUntil = JsonConvert.SerializeObject(_createdClaim.ValidUntil);
+            var formattedRetentionExpiresAt = JsonConvert.SerializeObject(_createdClaim.RetentionExpiresAt);
+            string expected = "{" +
+                               $"\"id\":\"{created.Id}\"," +
+                               $"\"createdAt\":{formattedCreatedAt}," +
+                               $"\"claimId\":\"{_createdClaim.Id}\"," +
+                               $"\"acceptedAt\":null," +
+                               $"\"rejectionReason\":null," +
+                               $"\"rejectedAt\":null,\"userUpdatedBy\":null," +
+                               $"\"claimValidUntil\":{formattedValidUntil}," +
+                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
+                               $"\"state\":\"UPLOADED\"," +
+                               "\"documentType\":{\"id\":\"proof-of-id\",\"title\":\"Proof of ID\",\"description\":\"A valid document that can be used to prove identity\"}," +
+                               "\"staffSelectedDocumentType\":null," +
+                               $"\"uploadPolicy\":{JsonConvert.SerializeObject(_createdUploadPolicy, Formatting.None)}," +
+                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\"" + "}" +
+                               "}";
+
+            json.Should().Be(expected);
+        }
+
+        [Test]
+        public async Task ReturnNotFoundWhenCannotFindEvidenceRequestWhenCreatingDocumentSubmission()
+        {
+            var fakeId = "ed0f2bd2-df90-4f01-b7f1-d30e402386d0";
+            string body = "{" +
+                          "\"documentType\": \"proof-of-id\"" +
+                          "}";
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/evidence_requests/{fakeId}/document_submissions", UriKind.Relative);
+            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(404);
+        }
+
+        [Test]
+        public async Task CreateDocumentSubmissionUnsuccessfulWhenCannotCreateUploadPolicy()
+        {
+            // Arrange
+            var entity = _fixture.Build<EvidenceRequest>()
+                .With(x => x.DocumentTypes, new List<string> { "passport-scan" })
+                .With(x => x.DeliveryMethods, new List<DeliveryMethod> { DeliveryMethod.Email })
+                .Without(x => x.Communications)
+                .Without(x => x.DocumentSubmissions)
+                .Create();
+            DatabaseContext.EvidenceRequests.Add(entity);
+            DatabaseContext.SaveChanges();
+
+            DocumentsApiServer.Reset();
+            DocumentsApiServer.Given(
+                Request.Create().WithPath("/api/v1/claims")
+            ).RespondWith(
+                Response.Create().WithStatusCode(201).WithBody(
+                    JsonConvert.SerializeObject(_createdClaim)
+                )
+            );
+            DocumentsApiServer.Given(
+                Request.Create().WithPath($"/api/v1/documents/{_id}/upload_policies")
+            ).RespondWith(
+                Response.Create().WithStatusCode(404)
+            );
+
+            var uri = new Uri($"api/v1/evidence_requests/{entity.Id}/document_submissions", UriKind.Relative);
+            string body = "{" +
+                          "\"documentType\": \"proof-of-id\"" +
+                          "}";
+
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+
+            // Act
+            var response = await Client.PostAsync(uri, jsonString).ConfigureAwait(true);
+
+            // Assert
+            response.StatusCode.Should().Be(400);
+        }
         [Test]
         public async Task CanGetEvidenceRequestsWithValidService()
         {

--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -239,7 +239,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
         }
 
         [Test]
-        public async Task CannotSendANotificationUploadConfirmationToResidentWhenCannotFindEvidenceRequest()
+        public async Task CannotSendANotificationUploadConfirmationToResidentAndStaffWhenCannotFindEvidenceRequest()
         {
             var id = Guid.NewGuid();
             var uri = new Uri($"api/v1/evidence_requests/{id}/confirmation", UriKind.Relative);
@@ -251,7 +251,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
         }
 
         [Test]
-        public async Task CannotSendANotificationUploadConfirmationToResidentWhenCannotFindResident()
+        public async Task CannotSendANotificationUploadConfirmationToResidentAndStaffWhenCannotFindResident()
         {
             var evidenceRequest = TestDataHelper.EvidenceRequest();
             DatabaseContext.EvidenceRequests.Add(evidenceRequest);
@@ -265,7 +265,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
         }
 
         [Test]
-        public async Task CannotSendANotificationUploadConfirmationToResidentWhenThereIsAGovNotifyError()
+        public async Task CannotSendANotificationUploadConfirmationToResidentAndStaffWhenThereIsAGovNotifyError()
         {
             var evidenceRequest = TestDataHelper.EvidenceRequest();
             var resident = TestDataHelper.Resident();

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -40,7 +40,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             var documentSubmissionRequest = _fixture.Build<DocumentSubmissionRequest>()
                 .Without(x => x.DocumentType)
                 .Create();
-            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest).ConfigureAwait(true);
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), documentSubmissionRequest);
             testDelegate.Should().Throw<BadRequestException>().WithMessage("Document type is null or empty");
         }
 
@@ -53,7 +53,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .Setup(x => x.CreateDocumentSubmission(It.Is<DocumentSubmission>(x => x.DocumentTypeId == request.DocumentType)))
                 .Returns(() => null)
                 .Verifiable();
-            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), request).ConfigureAwait(true);
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(Guid.NewGuid(), request);
             testDelegate.Should().Throw<NotFoundException>();
         }
 
@@ -79,7 +79,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .Throws(new DocumentsApiException("doh!"));
 
             // Act
-            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request).ConfigureAwait(true);
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request);
 
             // Assert
             testDelegate.Should().Throw<BadRequestException>();
@@ -115,7 +115,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .Throws(new DocumentsApiException("doh!"));
 
             // Act
-            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request).ConfigureAwait(true);
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request);
 
             // Assert
             testDelegate.Should().Throw<BadRequestException>();
@@ -158,7 +158,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             SetupEvidenceGateway(evidenceRequest);
             SetupDocumentsApiGateway(evidenceRequest, claim, s3UploadPolicy);
             _updateEvidenceRequestStateUseCase.Setup(x => x.Execute(_created.EvidenceRequestId)).Returns(evidenceRequest).Verifiable();
-            var result = await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request).ConfigureAwait(true);
+            var result = await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request);
             _updateEvidenceRequestStateUseCase.Verify(x => x.Execute(_created.EvidenceRequestId), Times.Once);
         }
 
@@ -181,7 +181,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             SetupDocumentsApiGateway(evidenceRequest, claim, s3UploadPolicy);
             SetupDocumentTypeGateway(_request.DocumentType);
 
-            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request).ConfigureAwait(true);
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request);
             testDelegate.Should().NotThrow();
         }
 
@@ -199,7 +199,7 @@ namespace EvidenceApi.Tests.V1.UseCase
 
             SetupEvidenceGateway(evidenceRequest);
 
-            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request).ConfigureAwait(true);
+            Func<Task<DocumentSubmissionResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request);
             testDelegate.Should().Throw<BadRequestException>();
         }
 

--- a/EvidenceApi.Tests/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaffTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaffTests.cs
@@ -13,13 +13,13 @@ using Notify.Exceptions;
 
 namespace EvidenceApi.Tests.V1.UseCase
 {
-    public class SendNotificationUploadConfirmationForResidentTests
+    public class SendNotificationUploadConfirmationToResidentAndStaffTests
     {
-        private SendNotificationUploadConfirmationForResident _classUnderTest;
+        private SendNotificationUploadConfirmationToResidentAndStaff _classUnderTest;
         private Mock<INotifyGateway> _notifyGateway;
         private Mock<IEvidenceGateway> _evidenceGateway;
         private Mock<IResidentsGateway> _residentsGateway;
-        private Mock<ILogger<SendNotificationUploadConfirmationForResident>> _logger;
+        private Mock<ILogger<SendNotificationUploadConfirmationToResidentAndStaff>> _logger;
         private Resident _resident;
         private EvidenceRequest _evidenceRequest;
 
@@ -29,8 +29,8 @@ namespace EvidenceApi.Tests.V1.UseCase
             _notifyGateway = new Mock<INotifyGateway>();
             _evidenceGateway = new Mock<IEvidenceGateway>();
             _residentsGateway = new Mock<IResidentsGateway>();
-            _logger = new Mock<ILogger<SendNotificationUploadConfirmationForResident>>();
-            _classUnderTest = new SendNotificationUploadConfirmationForResident(_notifyGateway.Object, _evidenceGateway.Object, _residentsGateway.Object, _logger.Object);
+            _logger = new Mock<ILogger<SendNotificationUploadConfirmationToResidentAndStaff>>();
+            _classUnderTest = new SendNotificationUploadConfirmationToResidentAndStaff(_notifyGateway.Object, _evidenceGateway.Object, _residentsGateway.Object, _logger.Object);
         }
 
         [Test]

--- a/EvidenceApi/Startup.cs
+++ b/EvidenceApi/Startup.cs
@@ -175,7 +175,7 @@ namespace EvidenceApi
             services.AddScoped<IFindDocumentSubmissionsByResidentIdUseCase, FindDocumentSubmissionsByResidentIdUseCase>();
             services.AddScoped<IFindOrCreateResidentReferenceIdUseCase, FindOrCreateResidentReferenceIdUseCase>();
             services.AddScoped<ICreateAuditUseCase, CreateAuditUseCase>();
-            services.AddScoped<ISendNotificationUploadConfirmationForResident, SendNotificationUploadConfirmationForResident>();
+            services.AddScoped<ISendNotificationUploadConfirmationToResidentAndStaff, SendNotificationUploadConfirmationToResidentAndStaff>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
+++ b/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
@@ -19,7 +19,7 @@ namespace EvidenceApi.V1.Controllers
         private readonly ICreateDocumentSubmissionUseCase _createDocumentSubmission;
         private readonly IFindEvidenceRequestByIdUseCase _evidenceRequestUseCase;
         private readonly IFindEvidenceRequestsUseCase _getEvidenceRequestsUseCase;
-        private readonly ISendNotificationUploadConfirmationForResident _sendNotificationUploadConfirmationForResident;
+        private readonly ISendNotificationUploadConfirmationToResidentAndStaff _sendNotificationUploadConfirmationToResidentAndStaff;
 
         public EvidenceRequestsController(
             ICreateEvidenceRequestUseCase creator,
@@ -27,14 +27,14 @@ namespace EvidenceApi.V1.Controllers
             IFindEvidenceRequestByIdUseCase evidenceRequestUseCase,
             IFindEvidenceRequestsUseCase getEvidenceRequestsUseCase,
             ICreateAuditUseCase createAuditUseCase,
-            ISendNotificationUploadConfirmationForResident sendNotificationUploadConfirmationForResident
+            ISendNotificationUploadConfirmationToResidentAndStaff sendNotificationUploadConfirmationToResidentAndStaff
         ) : base(createAuditUseCase)
         {
             _creator = creator;
             _createDocumentSubmission = createDocumentSubmission;
             _evidenceRequestUseCase = evidenceRequestUseCase;
             _getEvidenceRequestsUseCase = getEvidenceRequestsUseCase;
-            _sendNotificationUploadConfirmationForResident = sendNotificationUploadConfirmationForResident;
+            _sendNotificationUploadConfirmationToResidentAndStaff = sendNotificationUploadConfirmationToResidentAndStaff;
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace EvidenceApi.V1.Controllers
         }
 
         /// <summary>
-        /// Sends a notification to the resident after successful upload 
+        /// Sends a notification to the resident and staff after successful upload
         /// </summary>
         /// <response code="200">Ok</response>
         /// <response code="400">GovNotify error</response>
@@ -141,7 +141,7 @@ namespace EvidenceApi.V1.Controllers
         {
             try
             {
-                _sendNotificationUploadConfirmationForResident.Execute(evidenceRequestId);
+                _sendNotificationUploadConfirmationToResidentAndStaff.Execute(evidenceRequestId);
                 return Ok();
             }
             catch (NotFoundException ex)

--- a/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
+++ b/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
@@ -137,7 +137,7 @@ namespace EvidenceApi.V1.Controllers
         /// <response code="404">Resident cannot be found</response>
         [HttpPost]
         [Route("{evidenceRequestId}/confirmation")]
-        public IActionResult UploadConfirmationForResident([FromRoute][Required] Guid evidenceRequestId)
+        public IActionResult UploadConfirmationToResidentAndStaff([FromRoute][Required] Guid evidenceRequestId)
         {
             try
             {

--- a/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
+++ b/EvidenceApi/V1/Controllers/EvidenceRequestsController.cs
@@ -95,7 +95,7 @@ namespace EvidenceApi.V1.Controllers
         {
             try
             {
-                var result = await _createDocumentSubmission.ExecuteAsync(evidenceRequestId, request).ConfigureAwait(true);
+                var result = await _createDocumentSubmission.ExecuteAsync(evidenceRequestId, request);
                 return Created(new Uri($"/evidence_requests/{evidenceRequestId}/document_submissions", UriKind.Relative), result);
             }
             catch (BadRequestException ex)

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -9,7 +9,6 @@ using EvidenceApi.V1.Domain;
 using EvidenceApi.V1.Factories;
 using System.Threading.Tasks;
 using EvidenceApi.V1.Domain.Enums;
-using Microsoft.Extensions.Logging;
 
 namespace EvidenceApi.V1.UseCase
 {
@@ -56,8 +55,8 @@ namespace EvidenceApi.V1.UseCase
             try
             {
                 var claimRequest = BuildClaimRequest(evidenceRequest);
-                claim = await _documentsApiGateway.CreateClaim(claimRequest).ConfigureAwait(true);
-                createdS3UploadPolicy = await _documentsApiGateway.CreateUploadPolicy(claim.Document.Id).ConfigureAwait(true);
+                claim = await _documentsApiGateway.CreateClaim(claimRequest);
+                createdS3UploadPolicy = await _documentsApiGateway.CreateUploadPolicy(claim.Document.Id);
             }
             catch (DocumentsApiException ex)
             {

--- a/EvidenceApi/V1/UseCase/Interfaces/ISendNotificationUploadConfirmationToResidentAndStaff.cs
+++ b/EvidenceApi/V1/UseCase/Interfaces/ISendNotificationUploadConfirmationToResidentAndStaff.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace EvidenceApi.V1.UseCase.Interfaces
 {
-    public interface ISendNotificationUploadConfirmationForResident
+    public interface ISendNotificationUploadConfirmationToResidentAndStaff
     {
         public void Execute(Guid evidenceRequestId);
     }

--- a/EvidenceApi/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaff.cs
+++ b/EvidenceApi/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaff.cs
@@ -9,18 +9,18 @@ using Notify.Exceptions;
 
 namespace EvidenceApi.V1.UseCase
 {
-    public class SendNotificationUploadConfirmationForResident : ISendNotificationUploadConfirmationForResident
+    public class SendNotificationUploadConfirmationToResidentAndStaff : ISendNotificationUploadConfirmationToResidentAndStaff
     {
         private readonly INotifyGateway _notifyGateway;
         private readonly IEvidenceGateway _evidenceGateway;
         private readonly IResidentsGateway _residentsGateway;
-        private readonly ILogger<SendNotificationUploadConfirmationForResident> _logger;
+        private readonly ILogger<SendNotificationUploadConfirmationToResidentAndStaff> _logger;
 
-        public SendNotificationUploadConfirmationForResident(
+        public SendNotificationUploadConfirmationToResidentAndStaff(
             INotifyGateway notifyGateway,
             IEvidenceGateway evidenceGateway,
             IResidentsGateway residentsGateway,
-            ILogger<SendNotificationUploadConfirmationForResident> logger)
+            ILogger<SendNotificationUploadConfirmationToResidentAndStaff> logger)
         {
             _notifyGateway = notifyGateway;
             _evidenceGateway = evidenceGateway;

--- a/EvidenceApi/V1/UseCase/SendUploadConfirmationToResidentUseCase.cs
+++ b/EvidenceApi/V1/UseCase/SendUploadConfirmationToResidentUseCase.cs
@@ -48,6 +48,7 @@ namespace EvidenceApi.V1.UseCase
                     try
                     {
                         _notifyGateway.SendNotificationUploadConfirmationForResident(dm, CommunicationReason.DocumentsUploadedResidentConfirmation, evidenceRequest, resident);
+                        _notifyGateway.SendNotificationDocumentUploaded(dm, CommunicationReason.DocumentUploaded, evidenceRequest, resident);
                     }
                     catch (NotifyClientException e)
                     {

--- a/EvidenceApi/V1/UseCase/UpdateEvidenceRequestStateUseCase.cs
+++ b/EvidenceApi/V1/UseCase/UpdateEvidenceRequestStateUseCase.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using EvidenceApi.V1.UseCase.Interfaces;
 using EvidenceApi.V1.Boundary.Response.Exceptions;
 using EvidenceApi.V1.Domain;
-using System.Collections.Generic;
 
 namespace EvidenceApi.V1.UseCase
 {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-905

## Describe this PR

### *What is the problem we're trying to solve*

At the moment, officers receive an email per document submission. So if a resident uploads 15 documents, the staff member will receive 15 emails. Not great, so we needed to reduce the amount that are sent.

### *What changes have we introduced*

I've added the new line of code so an existing endpoint so that when a resident clicks 'submit', it sends an email to the staff member (as well as a confirmation to the resident). This required a lot of renaming and I've updated the tests to capture this change. I've removed `ConfigureAwait(true)` in the relevant files, because we're suppressing that error. I've also done some refactoring of the CreateDocumentSubmission tests, as they were in a different file. 

The new behaviour is now whenever a resident clicks 'submit', one email is sent to an officer.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Merge both FE and Evidence API and test manually in staging.
