### PR TITLE
Fix rejected document mentioning the wrong document in the email

### DIFF
--- a/EvidenceApi/V1/Gateways/NotifyGateway.cs
+++ b/EvidenceApi/V1/Gateways/NotifyGateway.cs
@@ -178,7 +178,7 @@ namespace EvidenceApi.V1.Gateways
                 return new Dictionary<string, object>
                 {
                     {"resident_name", resident.Name},
-                    {"evidence_item", GetDocumentType(documentSubmission.EvidenceRequest).Title},
+                    {"evidence_item", GetDocumentType(documentSubmission.EvidenceRequest, documentSubmission.DocumentTypeId).Title},
                     {"rejection_reason", documentSubmission.RejectionReason},
                     {"magic_link", MagicLinkFor(documentSubmission.EvidenceRequest)}
                 };
@@ -199,9 +199,9 @@ namespace EvidenceApi.V1.Gateways
             throw new ArgumentOutOfRangeException(nameof(communicationReason), communicationReason, $"Communication Reason {communicationReason.ToString()} not recognised");
         }
 
-        private DocumentType GetDocumentType(EvidenceRequest evidenceRequest)
+        private DocumentType GetDocumentType(EvidenceRequest evidenceRequest, string documentTypeId)
         {
-            return _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(evidenceRequest.Team, evidenceRequest.DocumentTypes[0]);
+            return _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(evidenceRequest.Team, documentTypeId);
         }
 
         private string MagicLinkFor(EvidenceRequest evidenceRequest) => $"{_options.EvidenceRequestClientUrl}resident/{evidenceRequest.Id}";


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-735

## Describe this PR

### *What changes have we introduced*

Previously, after a resident uploaded multiple documents, if the staff member rejected any of them the email to resident will mention that a different document was rejected instead of the correct one. This PR fixes that bug and now properly displays in the email to the resident the document that was rejected.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly