### PR TITLE
Bug fix for trying to send an SMS to notify staff members when documents are uploaded

### DIFF
--- a/EvidenceApi.Tests/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaffTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaffTests.cs
@@ -54,9 +54,6 @@ namespace EvidenceApi.Tests.V1.UseCase
             act.Should().NotThrow();
             _notifyGateway.Verify(x =>
                 x.SendNotificationDocumentUploaded(DeliveryMethod.Email, CommunicationReason.DocumentUploaded, _evidenceRequest, _resident));
-
-            _notifyGateway.Verify(x =>
-                x.SendNotificationDocumentUploaded(DeliveryMethod.Sms, CommunicationReason.DocumentUploaded, _evidenceRequest, _resident));
         }
 
         [Test]

--- a/EvidenceApi/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaff.cs
+++ b/EvidenceApi/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaff.cs
@@ -48,7 +48,10 @@ namespace EvidenceApi.V1.UseCase
                     try
                     {
                         _notifyGateway.SendNotificationUploadConfirmationForResident(dm, CommunicationReason.DocumentsUploadedResidentConfirmation, evidenceRequest, resident);
-                        _notifyGateway.SendNotificationDocumentUploaded(dm, CommunicationReason.DocumentUploaded, evidenceRequest, resident);
+                        if (dm == DeliveryMethod.Email)
+                        {
+                            _notifyGateway.SendNotificationDocumentUploaded(dm, CommunicationReason.DocumentUploaded, evidenceRequest, resident);
+                        }
                     }
                     catch (NotifyClientException e)
                     {

--- a/EvidenceApi/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaff.cs
+++ b/EvidenceApi/V1/UseCase/SendNotificationUploadConfirmationToResidentAndStaff.cs
@@ -48,10 +48,6 @@ namespace EvidenceApi.V1.UseCase
                     try
                     {
                         _notifyGateway.SendNotificationUploadConfirmationForResident(dm, CommunicationReason.DocumentsUploadedResidentConfirmation, evidenceRequest, resident);
-                        if (dm == DeliveryMethod.Email)
-                        {
-                            _notifyGateway.SendNotificationDocumentUploaded(dm, CommunicationReason.DocumentUploaded, evidenceRequest, resident);
-                        }
                     }
                     catch (NotifyClientException e)
                     {
@@ -60,6 +56,7 @@ namespace EvidenceApi.V1.UseCase
                     }
                 }
             );
+            _notifyGateway.SendNotificationDocumentUploaded(DeliveryMethod.Email, CommunicationReason.DocumentUploaded, evidenceRequest, resident);
         }
     }
 }


### PR DESCRIPTION
## Describe this PR

### *What changes have we introduced*

When documents are uploaded, staff members are notified by email that someone has uploaded documents. When both email and SMS options were selected for an evidence request the system was also trying to send an SMS to the staff member but wasn't able to find a GovNotify template (as there shouldn't be one). This fix makes the call to the GovNotify gateway to send only an email notification to staff regardless of the delivery method selected in the evidence request creation step.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
