### PR TITLE
add validation for bespoke note

### DIFF
--- a/EvidenceApi.Tests/V1/UseCase/EvidenceRequestValidatorTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/EvidenceRequestValidatorTests.cs
@@ -157,19 +157,15 @@ namespace EvidenceApi.Tests.V1.UseCase
         {
             _request.NoteToResident = "The image is not clear.";
             _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.NoteToResident, _request);
-
         }
 
         [Test]
         public void IsNoteToResidentOverCharacterLimit()
-
         {
-            int multiplier = 5001;
+            var multiplier = 5001;
             _request.NoteToResident = new string('A', multiplier);
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.NoteToResident, _request).WithErrorMessage("Maximum character count is 5000");
-
         }
-
 
         #endregion
 
@@ -179,8 +175,6 @@ namespace EvidenceApi.Tests.V1.UseCase
             var documentTypes = new List<DocumentType>() { documentType };
             _mockDocumentGateway.Setup(x => x.GetDocumentTypesByTeamName(team)).Returns(documentTypes);
         }
-
-
 
         private static EvidenceRequestRequest CreateRequest()
         {

--- a/EvidenceApi/V1/UseCase/EvidenceRequestValidator.cs
+++ b/EvidenceApi/V1/UseCase/EvidenceRequestValidator.cs
@@ -38,16 +38,13 @@ namespace EvidenceApi.V1.UseCase
             RuleForEach(x => x.DeliveryMethods)
                 .IsEnumName(typeof(DeliveryMethod), false);
 
-
-
             RuleFor(x => x.Resident)
                 .NotEmpty()
                 .SetValidator(residentValidator);
 
-
-            RuleFor(x => x.NoteToResident).MaximumLength(5000).WithMessage("Maximum character count is 5000");
-
-
+            RuleFor(x => x.NoteToResident)
+                .MaximumLength(5000)
+                .WithMessage("Maximum character count is 5000");
         }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1011


## Describe this PR

### *What is the problem we're trying to solve*

We researched that there is a hard limit of 1 GB in PostGres for a single column value.
 Following that, we discussed adding a constraint to the string length of bespoke note at the API level.

### *What changes have we introduced*

Added a new rule under evidence request validator.
Added test to cover the new rule.

Include any links to commits that introduce significant additions of code if they help explain the process of coming to the solution. e.g Addition of test database setup, the addition of first test and production class, removal of buggy code, etc.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to be addressed after merging this PR? Add them here.

Demo of the changes
