### PR TITLE
Decrease SemaphoreSlim number of throttled requests and add delay

### DIFF
--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -78,7 +78,7 @@ namespace EvidenceApi.V1.Gateways
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiGetClaimsToken);
 
-            var throttler = new SemaphoreSlim(10);
+            var throttler = new SemaphoreSlim(5);
             var tasks = claimIds.Select(async claimId =>
             {
                 await throttler.WaitAsync();
@@ -90,7 +90,6 @@ namespace EvidenceApi.V1.Gateways
                     throw new DocumentsApiException($"Incorrect status code returned: {response.StatusCode}");
                 }
 
-                await Task.Delay(200);
                 throttler.Release();
 
                 return await DeserializeResponse<Claim>(response);

--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -78,7 +78,7 @@ namespace EvidenceApi.V1.Gateways
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiGetClaimsToken);
 
-            var throttler = new SemaphoreSlim(20);
+            var throttler = new SemaphoreSlim(10);
             var tasks = claimIds.Select(async claimId =>
             {
                 await throttler.WaitAsync();
@@ -90,6 +90,7 @@ namespace EvidenceApi.V1.Gateways
                     throw new DocumentsApiException($"Incorrect status code returned: {response.StatusCode}");
                 }
 
+                await Task.Delay(200);
                 throttler.Release();
 
                 return await DeserializeResponse<Claim>(response);


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1082

## Describe this PR

### *What changes have we introduced*

Decreased the number of throttled requests to 10 and added a 200ms delay in between requests. This was done in order to try and reduce the pressure on the lambda authorizer dynamo db read capacity which is currently limited to 10 read units.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
