### PR TITLE
Add evidenceRequestId to DocumentSubmissionResponse

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -86,7 +86,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             var documentType = TestDataHelper.DocumentType("passport-scan");
             var staffSelectedDocumentType = TestDataHelper.DocumentType("drivers-licence");
-            var expected = createdDocumentSubmission.ToResponse(documentType, staffSelectedDocumentType);
+            var expected = createdDocumentSubmission.ToResponse(documentType, createdDocumentSubmission.EvidenceRequestId, staffSelectedDocumentType);
             result.Should().BeEquivalentTo(expected);
         }
 
@@ -153,7 +153,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var jsonFind = await responseFind.Content.ReadAsStringAsync().ConfigureAwait(true);
             var result = JsonConvert.DeserializeObject<DocumentSubmissionResponse>(jsonFind);
 
-            var expected = documentSubmission.ToResponse(null, null, null, _createdClaim);
+            var expected = documentSubmission.ToResponse(null, documentSubmission.EvidenceRequestId, null, null, _createdClaim);
 
             responseFind.StatusCode.Should().Be(200);
             result.Should().BeEquivalentTo(expected);
@@ -228,8 +228,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             var expected = new List<DocumentSubmissionResponse>()
             {
-                documentSubmission1.ToResponse(documentType,  null, null, _createdClaim),
-                documentSubmission2.ToResponse(documentType,  null, null, _createdClaim)
+                documentSubmission1.ToResponse(documentType, documentSubmission1.EvidenceRequestId, null, null, _createdClaim),
+                documentSubmission2.ToResponse(documentType, documentSubmission2.EvidenceRequestId, null, null, _createdClaim)
             };
 
             response.StatusCode.Should().Be(200);

--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -280,6 +280,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             string expected = "{" +
                                $"\"id\":\"{created.Id}\"," +
                                $"\"createdAt\":{formattedCreatedAt}," +
+                               $"\"evidenceRequestId\":\"{created.EvidenceRequestId}\"," +
                                $"\"claimId\":\"{_createdClaim.Id}\"," +
                                $"\"acceptedAt\":null," +
                                $"\"rejectionReason\":null," +

--- a/EvidenceApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/EvidenceApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -53,10 +53,11 @@ namespace EvidenceApi.Tests.V1.Factories
             var domain = TestDataHelper.DocumentSubmission();
             var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
 
-            var response = domain.ToResponse(documentType, null, s3UploadPolicy);
+            var response = domain.ToResponse(documentType, domain.EvidenceRequestId, null, s3UploadPolicy);
 
             response.Id.Should().Be(domain.Id);
             response.CreatedAt.Should().Be(domain.CreatedAt);
+            response.EvidenceRequestId.Should().Be(domain.EvidenceRequestId);
             response.ClaimId.Should().Be(domain.ClaimId);
             response.AcceptedAt.Should().Be(domain.AcceptedAt);
             response.RejectionReason.Should().Be(domain.RejectionReason);
@@ -75,10 +76,11 @@ namespace EvidenceApi.Tests.V1.Factories
             var domain = TestDataHelper.DocumentSubmission();
             var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
 
-            var response = domain.ToResponse(documentType, null, s3UploadPolicy, claim);
+            var response = domain.ToResponse(documentType, domain.EvidenceRequestId, null, s3UploadPolicy, claim);
 
             response.Id.Should().Be(domain.Id);
             response.CreatedAt.Should().Be(domain.CreatedAt);
+            response.EvidenceRequestId.Should().Be(domain.EvidenceRequestId);
             response.ClaimId.Should().Be(domain.ClaimId);
             response.AcceptedAt.Should().Be(domain.AcceptedAt);
             response.RejectionReason.Should().Be(domain.RejectionReason);

--- a/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
@@ -8,7 +8,7 @@ namespace EvidenceApi.V1.Boundary.Response
     {
         public Guid Id { get; set; }
         public DateTime CreatedAt { get; set; }
-        public Guid EvidenceRequestId {get; set; }
+        public Guid EvidenceRequestId { get; set; }
         public string ClaimId { get; set; }
         public DateTime? AcceptedAt { get; set; }
         public string RejectionReason { get; set; }

--- a/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
@@ -8,6 +8,7 @@ namespace EvidenceApi.V1.Boundary.Response
     {
         public Guid Id { get; set; }
         public DateTime CreatedAt { get; set; }
+        public Guid EvidenceRequestId {get; set; }
         public string ClaimId { get; set; }
         public DateTime? AcceptedAt { get; set; }
         public string RejectionReason { get; set; }

--- a/EvidenceApi/V1/Factories/ResponseFactory.cs
+++ b/EvidenceApi/V1/Factories/ResponseFactory.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using EvidenceApi.V1.Boundary.Response;
 using EvidenceApi.V1.Domain;
+using System;
 #nullable enable annotations
 
 namespace EvidenceApi.V1.Factories
@@ -38,6 +39,7 @@ namespace EvidenceApi.V1.Factories
         public static DocumentSubmissionResponse ToResponse(
             this DocumentSubmission domain,
             DocumentType documentType,
+            Guid evidenceRequestId,
             DocumentType? staffSelectedDocumentType = null,
             S3UploadPolicy? s3UploadPolicy = null,
             Claim? claim = null
@@ -54,6 +56,7 @@ namespace EvidenceApi.V1.Factories
                 UserUpdatedBy = domain.UserUpdatedBy,
                 State = domain.State.ToString().ToUpper(),
                 DocumentType = documentType,
+                EvidenceRequestId = evidenceRequestId,
                 StaffSelectedDocumentType = staffSelectedDocumentType,
                 UploadPolicy = s3UploadPolicy
             } : new DocumentSubmissionResponse()
@@ -67,6 +70,7 @@ namespace EvidenceApi.V1.Factories
                 UserUpdatedBy = domain.UserUpdatedBy,
                 State = domain.State.ToString().ToUpper(),
                 DocumentType = documentType,
+                EvidenceRequestId = evidenceRequestId,
                 StaffSelectedDocumentType = staffSelectedDocumentType,
                 UploadPolicy = s3UploadPolicy,
                 Document = claim.Document,

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -68,7 +68,7 @@ namespace EvidenceApi.V1.UseCase
             var documentType = _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(evidenceRequest.Team, documentSubmission.DocumentTypeId);
             _updateEvidenceRequestStateUseCase.Execute(createdDocumentSubmission.EvidenceRequestId);
 
-            return createdDocumentSubmission.ToResponse(documentType, null, createdS3UploadPolicy, claim);
+            return createdDocumentSubmission.ToResponse(documentType, documentSubmission.EvidenceRequestId, null, createdS3UploadPolicy, claim);
         }
 
         private static ClaimRequest BuildClaimRequest(EvidenceRequest evidenceRequest)

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionByIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionByIdUseCase.cs
@@ -45,7 +45,7 @@ namespace EvidenceApi.V1.UseCase
             try
             {
                 var claim = await _documentsApiGateway.GetClaimById(found.ClaimId).ConfigureAwait(true);
-                return found.ToResponse(documentType, staffSelectedDocumentType, null, claim);
+                return found.ToResponse(documentType, found.EvidenceRequestId, staffSelectedDocumentType, null, claim);
             }
             catch (DocumentsApiException ex)
             {

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -55,7 +55,7 @@ namespace EvidenceApi.V1.UseCase
                     var documentType = FindDocumentType(evidenceReq.Team, ds.DocumentTypeId);
                     var staffSelectedDocumentType = FindStaffSelectedDocumentType(evidenceReq.Team,
                         ds.StaffSelectedDocumentTypeId);
-                    result.Add(ds.ToResponse(documentType, staffSelectedDocumentType, null, claims[claimIndex]));
+                    result.Add(ds.ToResponse(documentType, ds.EvidenceRequestId, staffSelectedDocumentType, null, claims[claimIndex]));
                     claimIndex++;
                 }
             }

--- a/EvidenceApi/V1/UseCase/UpdateDocumentSubmissionStateUseCase.cs
+++ b/EvidenceApi/V1/UseCase/UpdateDocumentSubmissionStateUseCase.cs
@@ -102,7 +102,7 @@ namespace EvidenceApi.V1.UseCase
             _updateEvidenceRequestStateUseCase.Execute(documentSubmission.EvidenceRequestId);
 
             var documentType = _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(documentSubmission.EvidenceRequest.Team, documentSubmission.DocumentTypeId);
-            return documentSubmission.ToResponse(documentType, staffSelectedDocumentType);
+            return documentSubmission.ToResponse(documentType, documentSubmission.EvidenceRequestId, staffSelectedDocumentType);
         }
 
         private static bool IsApprovalRequest(DocumentSubmission documentSubmission)


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-852

## Describe this PR

### *What changes have we introduced*

Add `evidenceRequestId` to the `DocumentSubmissionResponse` so that we can associate evidence requests with document submissions in the frontend. This is useful for identifying the document types that haven't been submitted yet.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
