### PR TITLE
Disable new dev config doc types

### DIFF
--- a/EvidenceApi/DocumentTypes.json
+++ b/EvidenceApi/DocumentTypes.json
@@ -49,7 +49,7 @@
         "id": "proof-of-address",
         "title": "Proof of address",
         "description": "A valid document that can be used to prove address",
-        "enabled": true
+        "enabled": false
       }
     ]
   },

--- a/EvidenceApi/StaffSelectedDocumentTypes.json
+++ b/EvidenceApi/StaffSelectedDocumentTypes.json
@@ -37,7 +37,7 @@
         "id": "utility-bill",
         "title": "Utility bills",
         "description": "Valid from the last 3 months",
-        "enabled": true
+        "enabled": false
       }
     ]
   },


### PR DESCRIPTION
## Link to JIRA ticket
Part of the testing for this ticket 
https://hackney.atlassian.net/browse/DOC-872

## Describe this PR

### *What is the problem we're trying to solve*

I've made an evidence request with 2 x proof of address and approved one to be utility bills. If we disable those types, we should still be able to view the documents, but not select them for any new evidence requests.

### *What changes have we introduced*

I've set proof of address and utility bills for the dev housing team to be false.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

See if I can view documents. Try to make new evidence request and check if the doc types are there or not.
