### PR TITLE
calling async functions within tests

### DIFF
--- a/EvidenceApi.Tests/V1/UseCase/UpdateDocumentSubmissionStateUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/UpdateDocumentSubmissionStateUseCaseTests.cs
@@ -146,7 +146,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void SendsANotification()
+        public async Task SendsANotification()
         {
             Guid id = Guid.NewGuid();
             SetupMocks(id, teamName);
@@ -156,7 +156,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .With(x => x.RejectionReason, "This is the rejection reason")
                 .Without(x => x.ValidUntil)
                 .Create();
-            _classUnderTest.ExecuteAsync(id, request);
+            await _classUnderTest.ExecuteAsync(id, request);
 
             _notifyGateway.Verify(x =>
                 x.SendNotificationEvidenceRejected(DeliveryMethod.Email, CommunicationReason.EvidenceRejected, _found, _resident));
@@ -167,7 +167,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void UpdateClaim()
+        public async Task UpdateClaim()
         {
             // Arrange
             Guid id = Guid.NewGuid();
@@ -182,7 +182,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 .Create();
 
             // Act
-            _classUnderTest.ExecuteAsync(id, request);
+            await _classUnderTest.ExecuteAsync(id, request);
 
             // Assert
             _documentsApiGateway.Verify(x =>


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1167

## Describe this PR

The compiler was  flagging a warning in two tests as the methods being called were asynchronous but the tests were returning void and not awaiting the response of the calls (warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.)
This PR aims to correct that.

### *What changes have we introduced*

Changes in two tests 


