### PR TITLE
DOC-1306 - Include Team on Document Submission

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -282,6 +282,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                                $"\"createdAt\":{formattedCreatedAt}," +
                                $"\"evidenceRequestId\":\"{created.EvidenceRequestId}\"," +
                                $"\"claimId\":\"{_createdClaim.Id}\"," +
+                               $"\"team\":\"{created.Team}\"," +
                                $"\"acceptedAt\":null," +
                                $"\"rejectionReason\":null," +
                                $"\"rejectedAt\":null,\"userUpdatedBy\":null," +

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -144,6 +144,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             result.State.Should().Be(_created.State.ToString().ToUpper());
             result.DocumentType.Should().Be(docType);
             result.UploadPolicy.Should().BeEquivalentTo(s3UploadPolicy);
+            result.Team.Should().BeEquivalentTo(_created.Team);
         }
 
         [Test]

--- a/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
@@ -10,6 +10,7 @@ namespace EvidenceApi.V1.Boundary.Response
         public DateTime CreatedAt { get; set; }
         public Guid EvidenceRequestId { get; set; }
         public string ClaimId { get; set; }
+        public string Team { get; set; }
         public DateTime? AcceptedAt { get; set; }
         public string RejectionReason { get; set; }
         public DateTime? RejectedAt { get; set; }
@@ -21,6 +22,6 @@ namespace EvidenceApi.V1.Boundary.Response
         public DocumentType? StaffSelectedDocumentType { get; set; }
         public S3UploadPolicy? UploadPolicy { get; set; }
         public Document? Document { get; set; }
-        public string Team { get; set; }
+
     }
 }

--- a/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
@@ -21,5 +21,6 @@ namespace EvidenceApi.V1.Boundary.Response
         public DocumentType? StaffSelectedDocumentType { get; set; }
         public S3UploadPolicy? UploadPolicy { get; set; }
         public Document? Document { get; set; }
+        public string Team { get; set; }
     }
 }

--- a/EvidenceApi/V1/Factories/ResponseFactory.cs
+++ b/EvidenceApi/V1/Factories/ResponseFactory.cs
@@ -58,7 +58,8 @@ namespace EvidenceApi.V1.Factories
                 DocumentType = documentType,
                 EvidenceRequestId = evidenceRequestId,
                 StaffSelectedDocumentType = staffSelectedDocumentType,
-                UploadPolicy = s3UploadPolicy
+                UploadPolicy = s3UploadPolicy,
+                Team = domain.Team
             } : new DocumentSubmissionResponse()
             {
                 Id = domain.Id,
@@ -75,7 +76,8 @@ namespace EvidenceApi.V1.Factories
                 UploadPolicy = s3UploadPolicy,
                 Document = claim.Document,
                 ClaimValidUntil = claim.ValidUntil,
-                RetentionExpiresAt = claim.RetentionExpiresAt
+                RetentionExpiresAt = claim.RetentionExpiresAt,
+                Team = domain.Team
             };
         }
     }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -95,7 +95,9 @@ namespace EvidenceApi.V1.UseCase
                 EvidenceRequest = evidenceRequest,
                 DocumentTypeId = request.DocumentType,
                 ClaimId = claim.Id.ToString(),
-                State = SubmissionState.Uploaded
+                State = SubmissionState.Uploaded,
+                Team = evidenceRequest.Team
+
             };
             return documentSubmission;
         }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/c/projects/DOC/boards/68?modal=detail&selectedIssue=DOC-1306


### *What is the problem we're trying to solve*

To enable us to allow teams to be linked to document submissions as well as evidence requests, the requesting team must be populated on the document submission. This is part of a larger piece of work to allow document submissions without evidence requests. This change is not breaking.

### *What changes have we introduced*

Added mapping and tests to map the team requesting the evidence to the document submission itself.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

