### PR TITLE
DOC-1322 - Adding ResidentId to DocumentSubmissions

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -283,6 +283,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                                $"\"evidenceRequestId\":\"{created.EvidenceRequestId}\"," +
                                $"\"claimId\":\"{_createdClaim.Id}\"," +
                                $"\"team\":\"{created.Team}\"," +
+                               $"\"residentId\":\"{created.ResidentId}\"," +
                                $"\"acceptedAt\":null," +
                                $"\"rejectionReason\":null," +
                                $"\"rejectedAt\":null,\"userUpdatedBy\":null," +

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -145,6 +145,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             result.DocumentType.Should().Be(docType);
             result.UploadPolicy.Should().BeEquivalentTo(s3UploadPolicy);
             result.Team.Should().BeEquivalentTo(_created.Team);
+            result.ResidentId.Should().Be(_created.ResidentId);
         }
 
         [Test]

--- a/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/DocumentSubmissionResponse.cs
@@ -11,6 +11,7 @@ namespace EvidenceApi.V1.Boundary.Response
         public Guid EvidenceRequestId { get; set; }
         public string ClaimId { get; set; }
         public string Team { get; set; }
+        public Guid? ResidentId { get; set; }
         public DateTime? AcceptedAt { get; set; }
         public string RejectionReason { get; set; }
         public DateTime? RejectedAt { get; set; }
@@ -22,6 +23,5 @@ namespace EvidenceApi.V1.Boundary.Response
         public DocumentType? StaffSelectedDocumentType { get; set; }
         public S3UploadPolicy? UploadPolicy { get; set; }
         public Document? Document { get; set; }
-
     }
 }

--- a/EvidenceApi/V1/Factories/ResponseFactory.cs
+++ b/EvidenceApi/V1/Factories/ResponseFactory.cs
@@ -59,7 +59,8 @@ namespace EvidenceApi.V1.Factories
                 EvidenceRequestId = evidenceRequestId,
                 StaffSelectedDocumentType = staffSelectedDocumentType,
                 UploadPolicy = s3UploadPolicy,
-                Team = domain.Team
+                Team = domain.Team,
+                ResidentId = domain.ResidentId
             } : new DocumentSubmissionResponse()
             {
                 Id = domain.Id,
@@ -77,7 +78,8 @@ namespace EvidenceApi.V1.Factories
                 Document = claim.Document,
                 ClaimValidUntil = claim.ValidUntil,
                 RetentionExpiresAt = claim.RetentionExpiresAt,
-                Team = domain.Team
+                Team = domain.Team,
+                ResidentId = domain.ResidentId
             };
         }
     }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -96,8 +96,8 @@ namespace EvidenceApi.V1.UseCase
                 DocumentTypeId = request.DocumentType,
                 ClaimId = claim.Id.ToString(),
                 State = SubmissionState.Uploaded,
-                Team = evidenceRequest.Team
-
+                Team = evidenceRequest.Team,
+                ResidentId = evidenceRequest.ResidentId
             };
             return documentSubmission;
         }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1322

## Describe this PR

This PR aims to save the resident_id not only on the evidence_requests table but also on the new resident_id column for document_submission, in the context of enabling the users to upload on behalf of residents.
This is a non breaking change. 

### *What changes have we introduced*

Added new field in the appropriate UseCase and responses

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Code pipeline builds correctly


