### PR TITLE
Add endpoint to create a document submission without an evidence request

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -22,6 +22,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
         private readonly IFixture _fixture = new Fixture();
         private Claim _createdClaim;
         private Document _document;
+        private S3UploadPolicy _createdUploadPolicy;
         private readonly Guid _id = Guid.NewGuid();
 
         [SetUp]
@@ -34,11 +35,29 @@ namespace EvidenceApi.Tests.V1.E2ETests
                 .With(x => x.Document, _document)
                 .Create();
 
+            _createdUploadPolicy = _fixture.Create<S3UploadPolicy>();
+
             DocumentsApiServer.Given(
                 Request.Create().WithPath($"/api/v1/claims/{_createdClaim.Id}").UsingGet()
             ).RespondWith(
                 Response.Create().WithStatusCode(200).WithBody(
                     JsonConvert.SerializeObject(_createdClaim)
+                )
+            );
+
+            DocumentsApiServer.Given(
+                Request.Create().WithPath("/api/v1/claims")
+            ).RespondWith(
+                Response.Create().WithStatusCode(201).WithBody(
+                    JsonConvert.SerializeObject(_createdClaim)
+                )
+            );
+
+            DocumentsApiServer.Given(
+                Request.Create().WithPath($"/api/v1/documents/{_id}/upload_policies")
+            ).RespondWith(
+                Response.Create().WithStatusCode(200).WithBody(
+                    JsonConvert.SerializeObject(_createdUploadPolicy)
                 )
             );
         }
@@ -87,7 +106,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             var documentType = TestDataHelper.DocumentType("passport-scan");
             var staffSelectedDocumentType = TestDataHelper.GetStaffSelectedDocumentTypeByTeamName("drivers-licence", teamName);
-            var expected = createdDocumentSubmission.ToResponse(documentType, createdDocumentSubmission.EvidenceRequestId, staffSelectedDocumentType);
+            var expected = createdDocumentSubmission.ToResponse(documentType, (Guid) createdDocumentSubmission.EvidenceRequestId, staffSelectedDocumentType);
             result.Should().BeEquivalentTo(expected);
         }
 
@@ -154,7 +173,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var jsonFind = await responseFind.Content.ReadAsStringAsync().ConfigureAwait(true);
             var result = JsonConvert.DeserializeObject<DocumentSubmissionResponse>(jsonFind);
 
-            var expected = documentSubmission.ToResponse(null, documentSubmission.EvidenceRequestId, null, null, _createdClaim);
+            var expected = documentSubmission.ToResponse(null, (Guid) documentSubmission.EvidenceRequestId, null, null, _createdClaim);
 
             responseFind.StatusCode.Should().Be(200);
             result.Should().BeEquivalentTo(expected);
@@ -229,8 +248,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             var expected = new List<DocumentSubmissionResponse>()
             {
-                documentSubmission1.ToResponse(documentType, documentSubmission1.EvidenceRequestId, null, null, _createdClaim),
-                documentSubmission2.ToResponse(documentType, documentSubmission2.EvidenceRequestId, null, null, _createdClaim)
+                documentSubmission1.ToResponse(documentType, (Guid)documentSubmission1.EvidenceRequestId, null, null, _createdClaim),
+                documentSubmission2.ToResponse(documentType, (Guid)documentSubmission2.EvidenceRequestId, null, null, _createdClaim)
             };
 
             response.StatusCode.Should().Be(200);
@@ -244,6 +263,90 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var fakeResidentId = Guid.NewGuid();
             var uri = new Uri($"api/v1/document_submissions?team={team}&residentId={fakeResidentId}", UriKind.Relative);
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
+            response.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public async Task CanCreateDocumentSubmissionWithoutEvidenceRequestWithValidParams()
+        {
+            var resident = TestDataHelper.Resident();
+            resident.Id = Guid.NewGuid();
+            DatabaseContext.Residents.Add(resident);
+            DatabaseContext.SaveChanges();
+
+            string body = "{" +
+                          $"\"residentId\": \"{resident.Id}\"," +
+                          "\"team\": \"Development Housing Team\"," +
+                          "\"userCreatedBy\": \"test-user\"," +
+                          "\"staffSelectedDocumentTypeId\": \"passport-scan\"," +
+                          "\"documentName\": \"some document name\"," +
+                          "\"documentDescription\": \"some document description\"" +
+                          "}";
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/document_submissions", UriKind.Relative);
+            var response = await Client.PostAsync(uri, jsonString);
+            response.StatusCode.Should().Be(201);
+
+            var json = await response.Content.ReadAsStringAsync();
+
+            var created = DatabaseContext.DocumentSubmissions.First();
+
+            var formattedCreatedAt = JsonConvert.SerializeObject(created.CreatedAt);
+            var formattedValidUntil = JsonConvert.SerializeObject(_createdClaim.ValidUntil);
+            var formattedRetentionExpiresAt = JsonConvert.SerializeObject(_createdClaim.RetentionExpiresAt);
+            string expected = "{" +
+                               $"\"id\":\"{created.Id}\"," +
+                               $"\"createdAt\":{formattedCreatedAt}," +
+                               $"\"claimId\":\"{_createdClaim.Id}\"," +
+                               $"\"team\":\"{created.Team}\"," +
+                               $"\"residentId\":\"{created.ResidentId}\"," +
+                               $"\"claimValidUntil\":{formattedValidUntil}," +
+                               $"\"retentionExpiresAt\":{formattedRetentionExpiresAt}," +
+                               $"\"state\":\"APPROVED\"," +
+                               "\"staffSelectedDocumentType\":{\"id\":\"passport-scan\",\"title\":\"Passport Scan\",\"description\":\"A valid passport open at the photo page\",\"enabled\":true}," +
+                               $"\"uploadPolicy\":{JsonConvert.SerializeObject(_createdUploadPolicy, Formatting.None)}," +
+                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\"" + "}" +
+                               "}";
+
+            json.Should().Be(expected);
+        }
+
+        [Test]
+        public async Task CannotCreateDocumentSubmissionWithoutEvidenceRequestWithInvalidParameters()
+        {
+            var resident = TestDataHelper.Resident();
+            resident.Id = Guid.NewGuid();
+            DatabaseContext.Residents.Add(resident);
+            DatabaseContext.SaveChanges();
+
+            string body = "{" +
+                          $"\"residentId\": \"{resident.Id}\"," +
+                          "\"team\": \"\"," +
+                          "\"userCreatedBy\": \"test-user\"," +
+                          "\"staffSelectedDocumentTypeId\": \"passport-scan\"," +
+                          "\"documentName\": \"some document name\"," +
+                          "\"documentDescription\": \"some document description\"" +
+                          "}";
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/document_submissions", UriKind.Relative);
+            var response = await Client.PostAsync(uri, jsonString);
+            response.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public async Task CannotCreateDocumentSubmissionWithoutEvidenceRequestIfResidentDoesNotExist()
+        {
+            string body = "{" +
+                          $"\"residentId\": \"{Guid.NewGuid()}\"," +
+                          "\"team\": \"Development Housing Team\"," +
+                          "\"userCreatedBy\": \"test-user\"," +
+                          "\"staffSelectedDocumentTypeId\": \"passport-scan\"," +
+                          "\"documentName\": \"some document name\"," +
+                          "\"documentDescription\": \"some document description\"" +
+                          "}";
+            var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
+            var uri = new Uri($"api/v1/document_submissions", UriKind.Relative);
+            var response = await Client.PostAsync(uri, jsonString);
             response.StatusCode.Should().Be(400);
         }
     }

--- a/EvidenceApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/EvidenceApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -5,6 +5,7 @@ using EvidenceApi.V1.Domain.Enums;
 using EvidenceApi.V1.Factories;
 using FluentAssertions;
 using NUnit.Framework;
+using System;
 
 namespace EvidenceApi.Tests.V1.Factories
 {
@@ -53,11 +54,11 @@ namespace EvidenceApi.Tests.V1.Factories
             var domain = TestDataHelper.DocumentSubmission();
             var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
 
-            var response = domain.ToResponse(documentType, domain.EvidenceRequestId, null, s3UploadPolicy);
+            var response = domain.ToResponse(documentType, (Guid) domain.EvidenceRequestId, null, s3UploadPolicy);
 
             response.Id.Should().Be(domain.Id);
             response.CreatedAt.Should().Be(domain.CreatedAt);
-            response.EvidenceRequestId.Should().Be(domain.EvidenceRequestId);
+            response.EvidenceRequestId.Should().Be((Guid) domain.EvidenceRequestId);
             response.ClaimId.Should().Be(domain.ClaimId);
             response.AcceptedAt.Should().Be(domain.AcceptedAt);
             response.RejectionReason.Should().Be(domain.RejectionReason);
@@ -76,11 +77,11 @@ namespace EvidenceApi.Tests.V1.Factories
             var domain = TestDataHelper.DocumentSubmission();
             var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
 
-            var response = domain.ToResponse(documentType, domain.EvidenceRequestId, null, s3UploadPolicy, claim);
+            var response = domain.ToResponse(documentType, (Guid) domain.EvidenceRequestId, null, s3UploadPolicy, claim);
 
             response.Id.Should().Be(domain.Id);
             response.CreatedAt.Should().Be(domain.CreatedAt);
-            response.EvidenceRequestId.Should().Be(domain.EvidenceRequestId);
+            response.EvidenceRequestId.Should().Be((Guid) domain.EvidenceRequestId);
             response.ClaimId.Should().Be(domain.ClaimId);
             response.AcceptedAt.Should().Be(domain.AcceptedAt);
             response.RejectionReason.Should().Be(domain.RejectionReason);
@@ -92,6 +93,29 @@ namespace EvidenceApi.Tests.V1.Factories
             response.RetentionExpiresAt.Should().Be(claim.RetentionExpiresAt);
             response.Document.Should().Be(claim.Document);
             response.UploadPolicy.Should().Be(s3UploadPolicy);
+        }
+
+        [Test]
+        public void CanMapADocumentSubmissionWithoutEvidenceRequestDomainObjectToAResponseObject()
+        {
+            var staffSelectedDocumentType = new DocumentType() { Id = "passport-scan", Title = "Passport" };
+            var claim = _fixture.Build<Claim>().Create();
+            var domain = TestDataHelper.DocumentSubmission();
+            var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
+
+            var response = domain.ToResponse(staffSelectedDocumentType, s3UploadPolicy, claim);
+
+            response.Id.Should().Be(domain.Id);
+            response.CreatedAt.Should().Be(domain.CreatedAt);
+            response.ClaimId.Should().Be(domain.ClaimId);
+            response.Team.Should().Be(domain.Team);
+            response.ResidentId.Should().Be(domain.ResidentId);
+            response.ClaimValidUntil.Should().Be(claim.ValidUntil);
+            response.RetentionExpiresAt.Should().Be(claim.RetentionExpiresAt);
+            response.State.Should().Be(domain.State.ToString().ToUpper());
+            response.StaffSelectedDocumentType.Should().Be(staffSelectedDocumentType);
+            response.UploadPolicy.Should().Be(s3UploadPolicy);
+            response.Document.Should().Be(claim.Document);
         }
     }
 }

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -159,9 +159,9 @@ namespace EvidenceApi.Tests.V1.UseCase
             _request = CreateRequestFixture();
             SetupEvidenceGateway(evidenceRequest);
             SetupDocumentsApiGateway(evidenceRequest, claim, s3UploadPolicy);
-            _updateEvidenceRequestStateUseCase.Setup(x => x.Execute(_created.EvidenceRequestId)).Returns(evidenceRequest).Verifiable();
+            _updateEvidenceRequestStateUseCase.Setup(x => x.Execute((Guid) _created.EvidenceRequestId)).Returns(evidenceRequest).Verifiable();
             var result = await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request);
-            _updateEvidenceRequestStateUseCase.Verify(x => x.Execute(_created.EvidenceRequestId), Times.Once);
+            _updateEvidenceRequestStateUseCase.Verify(x => x.Execute((Guid) _created.EvidenceRequestId), Times.Once);
         }
 
         [TestCase(SubmissionState.Pending)]

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests.cs
@@ -1,0 +1,215 @@
+using System;
+using AutoFixture;
+using EvidenceApi.V1.Boundary.Request;
+using EvidenceApi.V1.Boundary.Response;
+using EvidenceApi.V1.Boundary.Response.Exceptions;
+using EvidenceApi.V1.Domain;
+using EvidenceApi.V1.Gateways.Interfaces;
+using EvidenceApi.V1.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace EvidenceApi.Tests.V1.UseCase
+{
+    public class CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests
+    {
+        private CreateDocumentSubmissionWithoutEvidenceRequestUseCase _classUnderTest;
+        private Mock<IEvidenceGateway> _evidenceGateway = new Mock<IEvidenceGateway>();
+        private Mock<IDocumentsApiGateway> _documentsApiGateway = new Mock<IDocumentsApiGateway>();
+        private Mock<IStaffSelectedDocumentTypeGateway> _staffSelectedDocumentTypeGateway = new Mock<IStaffSelectedDocumentTypeGateway>();
+        private readonly IFixture _fixture = new Fixture();
+        private DocumentType _staffSelectedDocumentType;
+        private DocumentSubmission _created;
+        private DocumentSubmissionWithoutEvidenceRequestRequest _request;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _classUnderTest = new CreateDocumentSubmissionWithoutEvidenceRequestUseCase(_evidenceGateway.Object, _documentsApiGateway.Object, _staffSelectedDocumentTypeGateway.Object);
+        }
+
+        [Test]
+        public void ThrowsBadRequestExceptionWhenTeamIsEmptyOrNull()
+        {
+            var documentSubmissionWithoutEvidenceRequestRequest = _fixture.Build<DocumentSubmissionWithoutEvidenceRequestRequest>()
+                .Without(x => x.Team)
+                .Create();
+            Func<Task<DocumentSubmissionWithoutEvidenceRequestResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(documentSubmissionWithoutEvidenceRequestRequest);
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("Team is null or empty");
+        }
+
+        [Test]
+        public void ThrowsBadRequestExceptionWhenUserCreatedByIsEmptyOrNull()
+        {
+            var documentSubmissionWithoutEvidenceRequestRequest = _fixture.Build<DocumentSubmissionWithoutEvidenceRequestRequest>()
+                .Without(x => x.UserCreatedBy)
+                .Create();
+            Func<Task<DocumentSubmissionWithoutEvidenceRequestResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(documentSubmissionWithoutEvidenceRequestRequest);
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("UserCreatedBy is null or empty");
+        }
+
+        [Test]
+        public void ThrowsBadRequestExceptionWhenStaffSelectedDocumentTypeIdIsEmptyOrNull()
+        {
+            var documentSubmissionWithoutEvidenceRequestRequest = _fixture.Build<DocumentSubmissionWithoutEvidenceRequestRequest>()
+                .Without(x => x.StaffSelectedDocumentTypeId)
+                .Create();
+            Func<Task<DocumentSubmissionWithoutEvidenceRequestResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(documentSubmissionWithoutEvidenceRequestRequest);
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("StaffSelectedDocumentTypeId is null or empty");
+        }
+
+        [Test]
+        public void ThrowsBadRequestExceptionWhenDocumentNameIsEmptyOrNull()
+        {
+            var documentSubmissionWithoutEvidenceRequestRequest = _fixture.Build<DocumentSubmissionWithoutEvidenceRequestRequest>()
+                .Without(x => x.DocumentName)
+                .Create();
+            Func<Task<DocumentSubmissionWithoutEvidenceRequestResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(documentSubmissionWithoutEvidenceRequestRequest);
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("DocumentName is null or empty");
+        }
+
+        [Test]
+        public void ThrowsBadRequestExceptionWhenDocumentDescriptionIsEmptyOrNull()
+        {
+            var documentSubmissionWithoutEvidenceRequestRequest = _fixture.Build<DocumentSubmissionWithoutEvidenceRequestRequest>()
+                .Without(x => x.DocumentDescription)
+                .Create();
+            Func<Task<DocumentSubmissionWithoutEvidenceRequestResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(documentSubmissionWithoutEvidenceRequestRequest);
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("DocumentDescription is null or empty");
+        }
+
+        [Test]
+        public void ThrowsBadRequestExceptionWhenCannotCreateClaim()
+        {
+            // Arrange
+            _staffSelectedDocumentType = _fixture.Create<DocumentType>();
+            _request = CreateRequestFixture();
+
+            _documentsApiGateway
+                .Setup(x =>
+                    x.CreateClaim(It.Is<ClaimRequest>(cr =>
+                        cr.ServiceAreaCreatedBy == _request.Team &&
+                        cr.UserCreatedBy == _request.UserCreatedBy &&
+                        cr.ApiCreatedBy == "evidence_api"
+                    ))
+                )
+                .Throws(new DocumentsApiException("error!"));
+
+            // Act
+            Func<Task<DocumentSubmissionWithoutEvidenceRequestResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(_request);
+
+            // Assert
+            testDelegate.Should().Throw<BadRequestException>();
+        }
+
+        [Test]
+        public void ThrowsBadRequestExceptionWhenCannotCreateUploadPolicy()
+        {
+            // Arrange
+            _staffSelectedDocumentType = _fixture.Create<DocumentType>();
+            _request = CreateRequestFixture();
+
+            var claim = _fixture.Create<Claim>();
+            _documentsApiGateway
+                .Setup(x =>
+                    x.CreateClaim(It.Is<ClaimRequest>(cr =>
+                        cr.ServiceAreaCreatedBy == _request.Team &&
+                        cr.UserCreatedBy == _request.UserCreatedBy &&
+                        cr.ApiCreatedBy == "evidence_api"
+                    ))
+                )
+                .ReturnsAsync(claim);
+
+            _documentsApiGateway
+                .Setup(x =>
+                    x.CreateUploadPolicy(It.Is<Guid>(id =>
+                        id == claim.Document.Id))
+                )
+                .Throws(new DocumentsApiException("error!"));
+
+            // Act
+            Func<Task<DocumentSubmissionWithoutEvidenceRequestResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(_request);
+
+            // Assert
+            testDelegate.Should().Throw<BadRequestException>();
+        }
+
+        [Test]
+        public async Task ReturnsTheCreatedDocumentSubmissionWithoutEvidenceRequestWhenRequestIsValid()
+        {
+            _staffSelectedDocumentType = _fixture.Create<DocumentType>();
+            _created = DocumentSubmissionFixture();
+            _request = CreateRequestFixture();
+
+            var claim = _fixture.Create<Claim>();
+            var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
+
+            SetupDocumentsApiGateway(_request, claim, s3UploadPolicy);
+            var staffSelectedDocumentType = SetupStaffSelectedDocumentTypeGateway(_request.StaffSelectedDocumentTypeId);
+            SetupEvidenceGateway();
+
+            var result = await _classUnderTest.ExecuteAsync(_request).ConfigureAwait(true);
+
+            result.Id.Should().Be(_created.Id);
+            result.ClaimId.Should().Be(_created.ClaimId);
+            result.State.Should().Be(_created.State.ToString().ToUpper());
+            result.StaffSelectedDocumentType.Should().Be(staffSelectedDocumentType);
+            result.UploadPolicy.Should().BeEquivalentTo(s3UploadPolicy);
+            result.Team.Should().BeEquivalentTo(_created.Team);
+            result.ResidentId.Should().Be(_created.ResidentId);
+        }
+
+        private DocumentSubmissionWithoutEvidenceRequestRequest CreateRequestFixture()
+        {
+            return _fixture.Build<DocumentSubmissionWithoutEvidenceRequestRequest>()
+                .With(x => x.StaffSelectedDocumentTypeId, _staffSelectedDocumentType.Id)
+                .Create();
+        }
+
+        private DocumentSubmission DocumentSubmissionFixture()
+        {
+            var submission = TestDataHelper.DocumentSubmission();
+            submission.Id = Guid.NewGuid();
+            submission.StaffSelectedDocumentTypeId = _staffSelectedDocumentType.Id;
+            return submission;
+        }
+
+        private void SetupDocumentsApiGateway(DocumentSubmissionWithoutEvidenceRequestRequest request, Claim claim, S3UploadPolicy s3UploadPolicy)
+        {
+            _documentsApiGateway
+                .Setup(x =>
+                    x.CreateClaim(It.Is<ClaimRequest>(cr =>
+                        cr.ServiceAreaCreatedBy == request.Team &&
+                        cr.UserCreatedBy == request.UserCreatedBy &&
+                        cr.ApiCreatedBy == "evidence_api"
+                    ))
+                )
+                .ReturnsAsync(claim);
+
+            _documentsApiGateway
+                 .Setup(x =>
+                     x.CreateUploadPolicy(It.Is<Guid>(id =>
+                         id == claim.Document.Id))
+                 )
+                 .ReturnsAsync(s3UploadPolicy);
+        }
+
+        private void SetupEvidenceGateway()
+        {
+            _evidenceGateway
+                .Setup(x => x.CreateDocumentSubmission(It.Is<DocumentSubmission>(x => x.StaffSelectedDocumentTypeId == _request.StaffSelectedDocumentTypeId)))
+                .Returns(_created)
+                .Verifiable();
+        }
+
+        private DocumentType SetupStaffSelectedDocumentTypeGateway(string staffSelectedDocumentTypeId)
+        {
+            var staffSelectedDocumentType = TestDataHelper.StaffSelectedDocumentType(staffSelectedDocumentTypeId);
+            _staffSelectedDocumentTypeGateway.Setup(x => x.GetDocumentTypeByTeamNameAndDocumentTypeId("team", staffSelectedDocumentTypeId)).Returns(staffSelectedDocumentType);
+
+            return staffSelectedDocumentType;
+        }
+    }
+}

--- a/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionByIdUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionByIdUseCaseTests.cs
@@ -112,8 +112,8 @@ namespace EvidenceApi.Tests.V1.UseCase
 
             _documentTypesGateway.Setup(x => x.GetDocumentTypeByTeamNameAndDocumentTypeId(It.IsAny<string>(), It.IsAny<string>())).Returns(_documentType);
             _staffSelectedDocumentTypeGateway.Setup(x => x.GetDocumentTypeByTeamNameAndDocumentTypeId(It.IsAny<string>(), It.IsAny<string>())).Returns(_documentType);
-            _evidenceGateway.Setup(x => x.FindEvidenceRequest(_found.EvidenceRequestId)).Returns(_found.EvidenceRequest);
-            _evidenceGateway.Setup(x => x.FindEvidenceRequest(_found2.EvidenceRequestId)).Returns(_found2.EvidenceRequest);
+            _evidenceGateway.Setup(x => x.FindEvidenceRequest((Guid) _found.EvidenceRequestId)).Returns(_found.EvidenceRequest);
+            _evidenceGateway.Setup(x => x.FindEvidenceRequest((Guid) _found2.EvidenceRequestId)).Returns(_found2.EvidenceRequest);
             _evidenceGateway.Setup(x => x.FindDocumentSubmission(_documentSubmissionId1)).Returns(_found);
             _evidenceGateway.Setup(x => x.FindDocumentSubmission(_documentSubmissionId2)).Returns(_found2);
             _documentsApiGateway.Setup(x => x.GetClaimById(_claimId1)).Returns(_claim1);

--- a/EvidenceApi.Tests/V1/UseCase/UpdateDocumentSubmissionStateUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/UpdateDocumentSubmissionStateUseCaseTests.cs
@@ -259,7 +259,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             _found.EvidenceRequest = _evidenceRequest;
             _found.EvidenceRequestId = _evidenceRequest.Id;
 
-            _evidenceGateway.Setup(x => x.FindEvidenceRequest(_found.EvidenceRequestId)).Returns(_evidenceRequest);
+            _evidenceGateway.Setup(x => x.FindEvidenceRequest((Guid) _found.EvidenceRequestId)).Returns(_evidenceRequest);
             _evidenceGateway.Setup(x => x.FindDocumentSubmission(id)).Returns(_found);
             _evidenceGateway.Setup(x => x.CreateDocumentSubmission(It.Is<DocumentSubmission>(ds =>
                 ds.Id == id && ds.State == SubmissionState.Uploaded
@@ -271,7 +271,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             _residentsGateway.Setup(x => x.FindResident(It.IsAny<Guid>())).Returns(_resident).Verifiable();
             _evidenceGateway.Setup(x => x.CreateEvidenceRequest(It.IsAny<EvidenceRequest>())).Returns(_evidenceRequest).Verifiable();
 
-            _updateEvidenceRequestStateUseCase.Setup(x => x.Execute(_found.EvidenceRequestId));
+            _updateEvidenceRequestStateUseCase.Setup(x => x.Execute((Guid) _found.EvidenceRequestId));
 
             var claim = _fixture.Create<Claim>();
             _documentsApiGateway.Setup(x => x.UpdateClaim(It.IsAny<Guid>(), It.IsAny<ClaimUpdateRequest>()))

--- a/EvidenceApi/Startup.cs
+++ b/EvidenceApi/Startup.cs
@@ -180,6 +180,7 @@ namespace EvidenceApi
             services
                 .AddScoped<IGetStaffSelectedDocumentTypesByTeamNameUseCase,
                     GetStaffSelectedDocumentTypesByTeamNameUseCase>();
+            services.AddScoped<ICreateDocumentSubmissionWithoutEvidenceRequestUseCase, CreateDocumentSubmissionWithoutEvidenceRequestUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/EvidenceApi/V1/Boundary/Request/DocumentSubmissionWithoutEvidenceRequestRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/DocumentSubmissionWithoutEvidenceRequestRequest.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace EvidenceApi.V1.Boundary.Request
+{
+    public class DocumentSubmissionWithoutEvidenceRequestRequest
+    {
+        public Guid ResidentId { get; set; }
+        public string Team { get; set; }
+        public string UserCreatedBy { get; set; }
+        public string StaffSelectedDocumentTypeId { get; set; }
+        public string DocumentName { get; set; }
+        public string DocumentDescription { get; set; }
+    }
+}

--- a/EvidenceApi/V1/Boundary/Response/DocumentSubmissionWithoutEvidenceRequestResponse.cs
+++ b/EvidenceApi/V1/Boundary/Response/DocumentSubmissionWithoutEvidenceRequestResponse.cs
@@ -1,0 +1,21 @@
+using System;
+using EvidenceApi.V1.Domain;
+#nullable enable annotations
+
+namespace EvidenceApi.V1.Boundary.Response
+{
+    public class DocumentSubmissionWithoutEvidenceRequestResponse
+    {
+        public Guid Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string ClaimId { get; set; }
+        public string Team { get; set; }
+        public Guid ResidentId { get; set; }
+        public DateTime ClaimValidUntil { get; set; }
+        public DateTime RetentionExpiresAt { get; set; }
+        public string State { get; set; }
+        public DocumentType StaffSelectedDocumentType { get; set; }
+        public S3UploadPolicy UploadPolicy { get; set; }
+        public Document Document { get; set; }
+    }
+}

--- a/EvidenceApi/V1/Controllers/DocumentSubmissionsController.cs
+++ b/EvidenceApi/V1/Controllers/DocumentSubmissionsController.cs
@@ -17,17 +17,20 @@ namespace EvidenceApi.V1.Controllers
         private readonly IUpdateDocumentSubmissionStateUseCase _updateDocumentSubmissionStateUseCase;
         private readonly IFindDocumentSubmissionByIdUseCase _findDocumentSubmissionByIdUseCase;
         private readonly IFindDocumentSubmissionsByResidentIdUseCase _findDocumentSubmissionsByResidentIdUseCase;
+        private readonly ICreateDocumentSubmissionWithoutEvidenceRequestUseCase _createDocumentSubmissionWithoutEvidenceRequestUseCase;
 
         public DocumentSubmissionsController(
             ICreateAuditUseCase createAuditUseCase,
             IUpdateDocumentSubmissionStateUseCase updateDocumentSubmissionStateUseCase,
             IFindDocumentSubmissionByIdUseCase findDocumentSubmissionByIdUseCase,
-            IFindDocumentSubmissionsByResidentIdUseCase findDocumentSubmissionsByResidentIdUseCase
+            IFindDocumentSubmissionsByResidentIdUseCase findDocumentSubmissionsByResidentIdUseCase,
+            ICreateDocumentSubmissionWithoutEvidenceRequestUseCase createDocumentSubmissionWithoutEvidenceRequestUseCase
         ) : base(createAuditUseCase)
         {
             _updateDocumentSubmissionStateUseCase = updateDocumentSubmissionStateUseCase;
             _findDocumentSubmissionByIdUseCase = findDocumentSubmissionByIdUseCase;
             _findDocumentSubmissionsByResidentIdUseCase = findDocumentSubmissionsByResidentIdUseCase;
+            _createDocumentSubmissionWithoutEvidenceRequestUseCase = createDocumentSubmissionWithoutEvidenceRequestUseCase;
         }
 
         /// <summary>
@@ -91,6 +94,26 @@ namespace EvidenceApi.V1.Controllers
             {
                 var result = await _findDocumentSubmissionsByResidentIdUseCase.ExecuteAsync(request).ConfigureAwait(true);
                 return Ok(result);
+            }
+            catch (BadRequestException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new document submission without an evidence request
+        /// </summary>
+        /// <response code="201">Saved</response>
+        /// <response code="400">Request contains invalid parameters</response>
+        /// <response code="401">Request lacks valid API token</response>
+        [HttpPost]
+        public async Task<IActionResult> CreateDocumentSubmissionWithoutEvidenceRequest([FromBody][Required] DocumentSubmissionWithoutEvidenceRequestRequest request)
+        {
+            try
+            {
+                var result = await _createDocumentSubmissionWithoutEvidenceRequestUseCase.ExecuteAsync(request);
+                return Created(new Uri($"/document_submissions", UriKind.Relative), result);
             }
             catch (BadRequestException ex)
             {

--- a/EvidenceApi/V1/Domain/DocumentSubmission.cs
+++ b/EvidenceApi/V1/Domain/DocumentSubmission.cs
@@ -34,7 +34,7 @@ namespace EvidenceApi.V1.Domain
 
         [Column("evidence_request_id")]
         [ForeignKey("EvidenceRequest")]
-        public Guid EvidenceRequestId { get; set; }
+        public Guid? EvidenceRequestId { get; set; } = null;
 
         [ForeignKey("EvidenceRequestId")]
         public virtual EvidenceRequest EvidenceRequest { get; set; }
@@ -47,7 +47,7 @@ namespace EvidenceApi.V1.Domain
 
         [Column("resident_id")]
         [ForeignKey("Resident")]
-        public Guid? ResidentId { get; set; }
+        public Guid ResidentId { get; set; }
 
         [ForeignKey("ResidentId")]
         public virtual Resident Resident { get; set; }

--- a/EvidenceApi/V1/Factories/ResponseFactory.cs
+++ b/EvidenceApi/V1/Factories/ResponseFactory.cs
@@ -82,5 +82,27 @@ namespace EvidenceApi.V1.Factories
                 ResidentId = domain.ResidentId
             };
         }
+
+        public static DocumentSubmissionWithoutEvidenceRequestResponse ToResponse(
+            this DocumentSubmission domain,
+            DocumentType staffSelectedDocumentType,
+            S3UploadPolicy? s3UploadPolicy = null,
+            Claim? claim = null)
+        {
+            return new DocumentSubmissionWithoutEvidenceRequestResponse()
+            {
+                Id = domain.Id,
+                CreatedAt = domain.CreatedAt,
+                ClaimId = domain.ClaimId,
+                State = domain.State.ToString().ToUpper(),
+                StaffSelectedDocumentType = staffSelectedDocumentType,
+                ResidentId = domain.ResidentId,
+                Team = domain.Team,
+                UploadPolicy = s3UploadPolicy,
+                Document = claim.Document,
+                ClaimValidUntil = claim.ValidUntil,
+                RetentionExpiresAt = claim.RetentionExpiresAt
+            };
+        }
     }
 }

--- a/EvidenceApi/V1/Gateways/NotifyGateway.cs
+++ b/EvidenceApi/V1/Gateways/NotifyGateway.cs
@@ -51,7 +51,7 @@ namespace EvidenceApi.V1.Gateways
             {
                 DeliveryMethod = deliveryMethod,
                 NotifyId = result.id,
-                EvidenceRequestId = documentSubmission.EvidenceRequestId,
+                EvidenceRequestId = (Guid) documentSubmission.EvidenceRequestId,
                 Reason = communicationReason,
                 TemplateId = templateId
             };

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -66,9 +66,13 @@ namespace EvidenceApi.V1.UseCase
             var documentSubmission = BuildDocumentSubmission(evidenceRequest, request, claim);
             var createdDocumentSubmission = _evidenceGateway.CreateDocumentSubmission(documentSubmission);
             var documentType = _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(evidenceRequest.Team, documentSubmission.DocumentTypeId);
-            _updateEvidenceRequestStateUseCase.Execute(createdDocumentSubmission.EvidenceRequestId);
 
-            return createdDocumentSubmission.ToResponse(documentType, documentSubmission.EvidenceRequestId, null, createdS3UploadPolicy, claim);
+            if (createdDocumentSubmission.EvidenceRequestId != null)
+            {
+                _updateEvidenceRequestStateUseCase.Execute((Guid) createdDocumentSubmission.EvidenceRequestId);
+            }
+
+            return createdDocumentSubmission.ToResponse(documentType, (Guid) documentSubmission.EvidenceRequestId, null, createdS3UploadPolicy, claim);
         }
 
         private static ClaimRequest BuildClaimRequest(EvidenceRequest evidenceRequest)
@@ -93,6 +97,7 @@ namespace EvidenceApi.V1.UseCase
             var documentSubmission = new DocumentSubmission()
             {
                 EvidenceRequest = evidenceRequest,
+                EvidenceRequestId = evidenceRequest.Id,
                 DocumentTypeId = request.DocumentType,
                 ClaimId = claim.Id.ToString(),
                 State = SubmissionState.Uploaded,

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
@@ -1,0 +1,126 @@
+using System;
+using EvidenceApi.V1.Boundary.Request;
+using EvidenceApi.V1.Boundary.Response;
+using EvidenceApi.V1.Boundary.Response.Exceptions;
+using EvidenceApi.V1.Gateways.Interfaces;
+using EvidenceApi.V1.UseCase.Interfaces;
+using EvidenceApi.V1.Domain;
+using EvidenceApi.V1.Factories;
+using System.Threading.Tasks;
+using EvidenceApi.V1.Domain.Enums;
+
+namespace EvidenceApi.V1.UseCase
+{
+    public class CreateDocumentSubmissionWithoutEvidenceRequestUseCase : ICreateDocumentSubmissionWithoutEvidenceRequestUseCase
+    {
+        private readonly IEvidenceGateway _evidenceGateway;
+        private readonly IDocumentsApiGateway _documentsApiGateway;
+        private readonly IStaffSelectedDocumentTypeGateway _staffSelectedDocumentTypeGateway;
+
+        public CreateDocumentSubmissionWithoutEvidenceRequestUseCase(
+            IEvidenceGateway evidenceGateway,
+            IDocumentsApiGateway documentsApiGateway,
+            IStaffSelectedDocumentTypeGateway staffSelectedDocumentTypeGateway)
+        {
+            _evidenceGateway = evidenceGateway;
+            _documentsApiGateway = documentsApiGateway;
+            _staffSelectedDocumentTypeGateway = staffSelectedDocumentTypeGateway;
+        }
+
+        public async Task<DocumentSubmissionWithoutEvidenceRequestResponse> ExecuteAsync(DocumentSubmissionWithoutEvidenceRequestRequest request)
+        {
+            ValidateRequest(request);
+
+            Claim claim;
+            S3UploadPolicy createdS3UploadPolicy;
+
+            try
+            {
+                var claimRequest = BuildClaimRequest(request);
+                claim = await _documentsApiGateway.CreateClaim(claimRequest);
+                createdS3UploadPolicy = await _documentsApiGateway.CreateUploadPolicy(claim.Document.Id);
+            }
+            catch (DocumentsApiException ex)
+            {
+                throw new BadRequestException($"Issue with DocumentsApi so cannot create DocumentSubmission: {ex.Message}");
+            }
+
+            var documentSubmission = BuildDocumentSubmission(request, claim);
+            var createdDocumentSubmission = new DocumentSubmission();
+            try
+            {
+                createdDocumentSubmission = _evidenceGateway.CreateDocumentSubmission(documentSubmission);
+            }
+            catch (Exception)
+            {
+                throw new BadRequestException($"A resident with ID {request.ResidentId} does not exist.");
+            }
+
+            var staffSelectedDocumentType = _staffSelectedDocumentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(request.Team, documentSubmission.StaffSelectedDocumentTypeId);
+
+            return createdDocumentSubmission.ToResponse(staffSelectedDocumentType, createdS3UploadPolicy, claim);
+        }
+
+        private static ClaimRequest BuildClaimRequest(DocumentSubmissionWithoutEvidenceRequestRequest request)
+        {
+            var claimRequest = new ClaimRequest()
+            {
+                ServiceAreaCreatedBy = request.Team,
+                UserCreatedBy = request.UserCreatedBy,
+                ApiCreatedBy = "evidence_api",
+                RetentionExpiresAt = DateTime.UtcNow.AddMonths(3).Date,
+                ValidUntil = DateTime.UtcNow.AddMonths(3).Date
+            };
+            return claimRequest;
+        }
+
+        private static DocumentSubmission BuildDocumentSubmission(
+            DocumentSubmissionWithoutEvidenceRequestRequest request,
+            Claim claim
+        )
+        {
+            var documentSubmission = new DocumentSubmission()
+            {
+                ClaimId = claim.Id.ToString(),
+                State = SubmissionState.Approved,
+                Team = request.Team,
+                ResidentId = request.ResidentId,
+                StaffSelectedDocumentTypeId = request.StaffSelectedDocumentTypeId
+            };
+            return documentSubmission;
+        }
+
+        private static void ValidateRequest(DocumentSubmissionWithoutEvidenceRequestRequest request)
+        {
+            if (request.ResidentId == null)
+            {
+                throw new BadRequestException("ResidentId is null");
+            }
+
+            if (String.IsNullOrEmpty(request.Team))
+            {
+                throw new BadRequestException("Team is null or empty");
+            }
+
+            if (String.IsNullOrEmpty(request.UserCreatedBy))
+            {
+                throw new BadRequestException("UserCreatedBy is null or empty");
+            }
+
+            if (String.IsNullOrEmpty(request.StaffSelectedDocumentTypeId))
+            {
+                throw new BadRequestException("StaffSelectedDocumentTypeId is null or empty");
+            }
+
+            if (String.IsNullOrEmpty(request.DocumentName))
+            {
+                throw new BadRequestException("DocumentName is null or empty");
+            }
+
+            if (String.IsNullOrEmpty(request.DocumentDescription))
+            {
+                throw new BadRequestException("DocumentDescription is null or empty");
+            }
+        }
+    }
+}

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionByIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionByIdUseCase.cs
@@ -38,14 +38,18 @@ namespace EvidenceApi.V1.UseCase
                 throw new NotFoundException($"Cannot find document submission with ID: {id}");
             }
 
-            var evidenceRequest = _evidenceGateway.FindEvidenceRequest(found.EvidenceRequestId);
+            var evidenceRequest = new EvidenceRequest();
+            if (found.EvidenceRequestId != null)
+            {
+                evidenceRequest = _evidenceGateway.FindEvidenceRequest((Guid) found.EvidenceRequestId);
+            }
             var documentType = FindDocumentType(evidenceRequest.Team, found.DocumentTypeId);
             var staffSelectedDocumentType = FindStaffSelectedDocumentType(evidenceRequest.Team,
                 found.StaffSelectedDocumentTypeId);
             try
             {
                 var claim = await _documentsApiGateway.GetClaimById(found.ClaimId).ConfigureAwait(true);
-                return found.ToResponse(documentType, found.EvidenceRequestId, staffSelectedDocumentType, null, claim);
+                return found.ToResponse(documentType, (Guid) found.EvidenceRequestId, staffSelectedDocumentType, null, claim);
             }
             catch (DocumentsApiException ex)
             {

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -55,7 +55,10 @@ namespace EvidenceApi.V1.UseCase
                     var documentType = FindDocumentType(evidenceReq.Team, ds.DocumentTypeId);
                     var staffSelectedDocumentType = FindStaffSelectedDocumentType(evidenceReq.Team,
                         ds.StaffSelectedDocumentTypeId);
-                    result.Add(ds.ToResponse(documentType, ds.EvidenceRequestId, staffSelectedDocumentType, null, claims[claimIndex]));
+                    if (ds.EvidenceRequestId != null)
+                    {
+                        result.Add(ds.ToResponse(documentType, (Guid) ds.EvidenceRequestId, staffSelectedDocumentType, null, claims[claimIndex]));
+                    }
                     claimIndex++;
                 }
             }

--- a/EvidenceApi/V1/UseCase/Interfaces/ICreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/Interfaces/ICreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
@@ -1,0 +1,12 @@
+using System;
+using EvidenceApi.V1.Boundary.Request;
+using EvidenceApi.V1.Boundary.Response;
+using System.Threading.Tasks;
+
+namespace EvidenceApi.V1.UseCase.Interfaces
+{
+    public interface ICreateDocumentSubmissionWithoutEvidenceRequestUseCase
+    {
+        Task<DocumentSubmissionWithoutEvidenceRequestResponse> ExecuteAsync(DocumentSubmissionWithoutEvidenceRequestRequest request);
+    }
+}

--- a/EvidenceApi/V1/UseCase/UpdateDocumentSubmissionStateUseCase.cs
+++ b/EvidenceApi/V1/UseCase/UpdateDocumentSubmissionStateUseCase.cs
@@ -99,10 +99,14 @@ namespace EvidenceApi.V1.UseCase
             }
 
             _evidenceGateway.CreateDocumentSubmission(documentSubmission);
-            _updateEvidenceRequestStateUseCase.Execute(documentSubmission.EvidenceRequestId);
+            if (documentSubmission.EvidenceRequestId != null)
+            {
+                _updateEvidenceRequestStateUseCase.Execute((Guid) documentSubmission.EvidenceRequestId);
+            }
+
 
             var documentType = _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(documentSubmission.EvidenceRequest.Team, documentSubmission.DocumentTypeId);
-            return documentSubmission.ToResponse(documentType, documentSubmission.EvidenceRequestId, staffSelectedDocumentType);
+            return documentSubmission.ToResponse(documentType, (Guid) documentSubmission.EvidenceRequestId, staffSelectedDocumentType);
         }
 
         private static bool IsApprovalRequest(DocumentSubmission documentSubmission)
@@ -143,7 +147,12 @@ namespace EvidenceApi.V1.UseCase
         private void NotifyResident(DocumentSubmission documentSubmission, DocumentSubmissionUpdateRequest request)
         {
             documentSubmission.RejectionReason = request.RejectionReason;
-            var evidenceRequest = _evidenceGateway.FindEvidenceRequest(documentSubmission.EvidenceRequestId);
+
+            EvidenceRequest evidenceRequest = new EvidenceRequest();
+            if (documentSubmission.EvidenceRequestId != null)
+            {
+                evidenceRequest = _evidenceGateway.FindEvidenceRequest((Guid) documentSubmission.EvidenceRequestId);
+            }
 
             if (evidenceRequest == null)
             {
@@ -173,7 +182,13 @@ namespace EvidenceApi.V1.UseCase
         {
             DocumentType staffSelectedDocumentType = null;
             documentSubmission.StaffSelectedDocumentTypeId = request.StaffSelectedDocumentTypeId;
-            var evidenceRequest = _evidenceGateway.FindEvidenceRequest(documentSubmission.EvidenceRequestId);
+
+            EvidenceRequest evidenceRequest = new EvidenceRequest();
+            if (documentSubmission.EvidenceRequestId != null)
+            {
+                evidenceRequest = _evidenceGateway.FindEvidenceRequest((Guid) documentSubmission.EvidenceRequestId);
+            }
+
             staffSelectedDocumentType = _staffSelectedDocumentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(
                 evidenceRequest.Team, request.StaffSelectedDocumentTypeId);
             return staffSelectedDocumentType;


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1277

## Describe this PR

### *What changes have we introduced*

Added a new endpoint to create a document submission without an existing evidence request.

- Added new use case to create a document submission without an evidence request
- Added a new endpoint
- Changed the property `EvidenceRequestId` on `DocumentSubmission` domain mode to be nullable
- Made the relevant code changes to adapt the code to support a nullable `Guid` (guard clauses and casts to `Guid`)
- Added unit and end to end tests

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
