### PR TITLE
Remove DocumentName from request to create document submission without evidence request

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -282,7 +282,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
                           "\"team\": \"Development Housing Team\"," +
                           "\"userCreatedBy\": \"test-user\"," +
                           "\"staffSelectedDocumentTypeId\": \"passport-scan\"," +
-                          "\"documentName\": \"some document name\"," +
                           "\"documentDescription\": \"some document description\"" +
                           "}";
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
@@ -308,7 +307,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                                $"\"state\":\"APPROVED\"," +
                                "\"staffSelectedDocumentType\":{\"id\":\"passport-scan\",\"title\":\"Passport Scan\",\"description\":\"A valid passport open at the photo page\",\"enabled\":true}," +
                                $"\"uploadPolicy\":{JsonConvert.SerializeObject(_createdUploadPolicy, Formatting.None)}," +
-                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\"" + "}" +
+                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\",\"documentDescription\":\"{_document.DocumentDescription}\"" + "}" +
                                "}";
 
             json.Should().Be(expected);
@@ -327,7 +326,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
                           "\"team\": \"\"," +
                           "\"userCreatedBy\": \"test-user\"," +
                           "\"staffSelectedDocumentTypeId\": \"passport-scan\"," +
-                          "\"documentName\": \"some document name\"," +
                           "\"documentDescription\": \"some document description\"" +
                           "}";
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
@@ -346,7 +344,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
                           "\"team\": \"Development Housing Team\"," +
                           "\"userCreatedBy\": \"test-user\"," +
                           "\"staffSelectedDocumentTypeId\": \"passport-scan\"," +
-                          "\"documentName\": \"some document name\"," +
                           "\"documentDescription\": \"some document description\"" +
                           "}";
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");

--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -307,7 +307,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                                $"\"state\":\"APPROVED\"," +
                                "\"staffSelectedDocumentType\":{\"id\":\"passport-scan\",\"title\":\"Passport Scan\",\"description\":\"A valid passport open at the photo page\",\"enabled\":true}," +
                                $"\"uploadPolicy\":{JsonConvert.SerializeObject(_createdUploadPolicy, Formatting.None)}," +
-                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\",\"documentDescription\":\"{_document.DocumentDescription}\"" + "}" +
+                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\",\"description\":\"{_document.Description}\"" + "}" +
                                "}";
 
             json.Should().Be(expected);

--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -293,7 +293,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                                "\"documentType\":{\"id\":\"proof-of-id\",\"title\":\"Proof of ID\",\"description\":\"A valid document that can be used to prove identity\",\"enabled\":true}," +
                                "\"staffSelectedDocumentType\":null," +
                                $"\"uploadPolicy\":{JsonConvert.SerializeObject(_createdUploadPolicy, Formatting.None)}," +
-                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\",\"documentDescription\":\"{_document.DocumentDescription}\"" + "}" +
+                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\",\"description\":\"{_document.Description}\"" + "}" +
                                "}";
 
             json.Should().Be(expected);

--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -293,7 +293,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                                "\"documentType\":{\"id\":\"proof-of-id\",\"title\":\"Proof of ID\",\"description\":\"A valid document that can be used to prove identity\",\"enabled\":true}," +
                                "\"staffSelectedDocumentType\":null," +
                                $"\"uploadPolicy\":{JsonConvert.SerializeObject(_createdUploadPolicy, Formatting.None)}," +
-                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\"" + "}" +
+                               $"\"document\":" + "{" + $"\"id\":\"{_document.Id}\",\"fileSize\":{_document.FileSize},\"fileType\":\"{_document.FileType}\",\"documentDescription\":\"{_document.DocumentDescription}\"" + "}" +
                                "}";
 
             json.Should().Be(expected);

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests.cs
@@ -61,16 +61,6 @@ namespace EvidenceApi.Tests.V1.UseCase
         }
 
         [Test]
-        public void ThrowsBadRequestExceptionWhenDocumentNameIsEmptyOrNull()
-        {
-            var documentSubmissionWithoutEvidenceRequestRequest = _fixture.Build<DocumentSubmissionWithoutEvidenceRequestRequest>()
-                .Without(x => x.DocumentName)
-                .Create();
-            Func<Task<DocumentSubmissionWithoutEvidenceRequestResponse>> testDelegate = async () => await _classUnderTest.ExecuteAsync(documentSubmissionWithoutEvidenceRequestRequest);
-            testDelegate.Should().Throw<BadRequestException>().WithMessage("'Document Name' must not be empty.");
-        }
-
-        [Test]
         public void ThrowsBadRequestExceptionWhenDocumentDescriptionIsEmptyOrNull()
         {
             var documentSubmissionWithoutEvidenceRequestRequest = _fixture.Build<DocumentSubmissionWithoutEvidenceRequestRequest>()

--- a/EvidenceApi/V1/Boundary/Request/ClaimRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/ClaimRequest.cs
@@ -7,6 +7,7 @@ namespace EvidenceApi.V1.Boundary.Request
         public string ServiceAreaCreatedBy { get; set; }
         public string UserCreatedBy { get; set; }
         public string ApiCreatedBy { get; set; }
+        public string DocumentDescription { get; set; }
         public DateTime RetentionExpiresAt { get; set; }
         public DateTime ValidUntil { get; set; }
     }

--- a/EvidenceApi/V1/Boundary/Request/DocumentSubmissionWithoutEvidenceRequestRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/DocumentSubmissionWithoutEvidenceRequestRequest.cs
@@ -8,7 +8,6 @@ namespace EvidenceApi.V1.Boundary.Request
         public string Team { get; set; }
         public string UserCreatedBy { get; set; }
         public string StaffSelectedDocumentTypeId { get; set; }
-        public string DocumentName { get; set; }
         public string DocumentDescription { get; set; }
     }
 }

--- a/EvidenceApi/V1/Domain/Claim.cs
+++ b/EvidenceApi/V1/Domain/Claim.cs
@@ -19,6 +19,6 @@ namespace EvidenceApi.V1.Domain
         public Guid Id { get; set; }
         public int FileSize { get; set; }
         public string FileType { get; set; }
-        public string DocumentDescription { get; set; }
+        public string Description { get; set; }
     }
 }

--- a/EvidenceApi/V1/Domain/Claim.cs
+++ b/EvidenceApi/V1/Domain/Claim.cs
@@ -19,5 +19,6 @@ namespace EvidenceApi.V1.Domain
         public Guid Id { get; set; }
         public int FileSize { get; set; }
         public string FileType { get; set; }
+        public string DocumentDescription { get; set; }
     }
 }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
@@ -75,7 +75,8 @@ namespace EvidenceApi.V1.UseCase
                 UserCreatedBy = request.UserCreatedBy,
                 ApiCreatedBy = "evidence_api",
                 RetentionExpiresAt = DateTime.UtcNow.AddMonths(3).Date,
-                ValidUntil = DateTime.UtcNow.AddMonths(3).Date
+                ValidUntil = DateTime.UtcNow.AddMonths(3).Date,
+                DocumentDescription = request.DocumentDescription
             };
             return claimRequest;
         }

--- a/EvidenceApi/V1/Validators/DocumentSubmissionWithoutEvidenceRequestRequestValidator.cs
+++ b/EvidenceApi/V1/Validators/DocumentSubmissionWithoutEvidenceRequestRequestValidator.cs
@@ -11,7 +11,6 @@ namespace EvidenceApi.V1.Validators
             RuleFor(x => x.Team).NotEmpty();
             RuleFor(x => x.UserCreatedBy).NotEmpty();
             RuleFor(x => x.StaffSelectedDocumentTypeId).NotEmpty();
-            RuleFor(x => x.DocumentName).NotEmpty();
             RuleFor(x => x.DocumentDescription).NotEmpty();
         }
     }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1279

## Describe this PR

### *What changes have we introduced*

Remove `DocumentName` from request to create document submission without an evidence request as there is no way to add a value for it at the moment.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly