### PR TITLE
DOC-1372 - Team Not Considered In Pagination Query

### DIFF
--- a/EvidenceApi.Tests/TestDataHelper.cs
+++ b/EvidenceApi.Tests/TestDataHelper.cs
@@ -48,6 +48,7 @@ namespace EvidenceApi.Tests
                 .With(x => x.ResidentId, residentId)
                 .With(x => x.EvidenceRequest, evidenceRequest)
                 .With(x => x.EvidenceRequestId, evidenceRequest.Id)
+                .With(x => x.Team)
                 .Without(x => x.CreatedAt)
                 .Create();
 

--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -223,10 +223,12 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             var resident = TestDataHelper.ResidentWithId(Guid.NewGuid());
 
+            var team = "Development Housing Team";
+
             var evidenceRequestId = Guid.NewGuid();
             var evidenceRequest = TestDataHelper.EvidenceRequest();
             evidenceRequest.Id = evidenceRequestId;
-            evidenceRequest.Team = "Development Housing Team";
+            evidenceRequest.Team = team;
 
             DatabaseContext.EvidenceRequests.Add(evidenceRequest);
             DatabaseContext.Residents.Add(resident);
@@ -235,6 +237,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             var documentSubmission1 = TestDataHelper.DocumentSubmissionWithResidentId(resident.Id, evidenceRequest);
             documentSubmission1.DocumentTypeId = documentType.Id;
+            documentSubmission1.Team = team;
             documentSubmission1.ClaimId = _createdClaim.Id.ToString();
 
             DatabaseContext.DocumentSubmissions.Add(documentSubmission1);
@@ -246,11 +249,23 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
             var result = JsonConvert.DeserializeObject<DocumentSubmissionResponseObject>(json);
 
-            var expected = new DocumentSubmissionResponseObject()
+            var expectedDocType = new DocumentType()
+            {
+                Description =
+                    "A valid passport open at the photo page",
+                Enabled =
+                    true,
+                Id =
+                    "passport-scan",
+                Title =
+                    "Passport",
+            };
+
+            var expected = new DocumentSubmissionResponseObject
             {
                 DocumentSubmissions = new List<DocumentSubmissionResponse>()
                 {
-                    documentSubmission1.ToResponse(null, documentSubmission1.EvidenceRequestId, null, null, _createdClaim),
+                    documentSubmission1.ToResponse(expectedDocType, documentSubmission1.EvidenceRequestId, null, null, _createdClaim),
                 },
                 Total = 1
             };

--- a/EvidenceApi.Tests/V1/Gateways/EvidenceGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/EvidenceGatewayTests.cs
@@ -404,6 +404,7 @@ namespace EvidenceApi.Tests.V1.Gateways
             var queryGuid = Guid.NewGuid();
             var resident = TestDataHelper.ResidentWithId(queryGuid);
             var evidenceRequest = TestDataHelper.EvidenceRequest();
+            var team = "testTeam";
 
             DatabaseContext.EvidenceRequests.Add(evidenceRequest);
             DatabaseContext.Residents.Add(resident);
@@ -411,7 +412,9 @@ namespace EvidenceApi.Tests.V1.Gateways
             DatabaseContext.SaveChanges();
 
             var documentSubmission1 = TestDataHelper.DocumentSubmissionWithResidentId(queryGuid, evidenceRequest);
+            documentSubmission1.Team = team;
             var documentSubmission2 = TestDataHelper.DocumentSubmissionWithResidentId(queryGuid, evidenceRequest);
+            documentSubmission2.Team = team;
 
             DatabaseContext.Entry(documentSubmission1).State = EntityState.Modified;
             DatabaseContext.DocumentSubmissions.Add(documentSubmission1);
@@ -422,7 +425,7 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             var expected = new List<DocumentSubmission>() { documentSubmission1, documentSubmission2 };
 
-            var result = _classUnderTest.GetPaginatedDocumentSubmissionsByResidentId(queryGuid);
+            var result = _classUnderTest.GetPaginatedDocumentSubmissionsByResidentId(queryGuid, team);
 
             result.Total.Should().Be(2);
             result.DocumentSubmissions.Should().Equal(expected);
@@ -437,6 +440,7 @@ namespace EvidenceApi.Tests.V1.Gateways
             var evidenceRequest = TestDataHelper.EvidenceRequest();
             var page = 1;
             var pageSize = 2;
+            var team = "testTeam";
 
             DatabaseContext.EvidenceRequests.Add(evidenceRequest);
             DatabaseContext.Residents.Add(resident);
@@ -444,8 +448,11 @@ namespace EvidenceApi.Tests.V1.Gateways
             DatabaseContext.SaveChanges();
 
             var documentSubmission1 = TestDataHelper.DocumentSubmissionWithResidentId(queryGuid, evidenceRequest);
+            documentSubmission1.Team = team;
             var documentSubmission2 = TestDataHelper.DocumentSubmissionWithResidentId(queryGuid, evidenceRequest);
+            documentSubmission2.Team = team;
             var documentSubmission3 = TestDataHelper.DocumentSubmissionWithResidentId(queryGuid, evidenceRequest);
+            documentSubmission3.Team = team;
             var documentSubmission4 = TestDataHelper.DocumentSubmissionWithResidentId(queryGuid, evidenceRequest);
 
             DatabaseContext.Entry(documentSubmission1).State = EntityState.Modified;
@@ -459,9 +466,9 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             DatabaseContext.SaveChanges();
 
-            var expected = new List<DocumentSubmission>() { documentSubmission4, documentSubmission3 };
+            var expected = new List<DocumentSubmission>() { documentSubmission3, documentSubmission2 };
 
-            var result = _classUnderTest.GetPaginatedDocumentSubmissionsByResidentId(queryGuid, pageSize, page);
+            var result = _classUnderTest.GetPaginatedDocumentSubmissionsByResidentId(queryGuid, team, pageSize, page);
 
             result.Total.Should().Be(4);
             result.DocumentSubmissions.Should().Equal(expected);

--- a/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCaseTests.cs
@@ -160,7 +160,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             _documentTypesGateway.Setup(x => x.GetDocumentTypeByTeamNameAndDocumentTypeId(It.IsAny<string>(), It.IsAny<string>())).Returns(_documentType);
             _staffSelectedDocumentTypeGateway.Setup(x => x.GetDocumentTypeByTeamNameAndDocumentTypeId(It.IsAny<string>(), It.IsAny<string>())).Returns(_documentType);
             _evidenceGateway
-                .Setup(x => x.GetPaginatedDocumentSubmissionsByResidentId(It.IsAny<Guid>(), It.IsAny<int?>(),
+                .Setup(x => x.GetPaginatedDocumentSubmissionsByResidentId(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int?>(),
                     It.IsAny<int?>())).Returns(_injectedResult);
             _documentsApiGateway.Setup(x => x.GetClaimById(_claimId1)).Returns(_claim1);
             _documentsApiGateway.Setup(x => x.GetClaimById(_claimId2)).Returns(_claim2);

--- a/EvidenceApi/Startup.cs
+++ b/EvidenceApi/Startup.cs
@@ -205,6 +205,7 @@ namespace EvidenceApi
                 }
             });
 
+            //allow legacy Postgres behaviour
             AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
             app.UseSwagger();

--- a/EvidenceApi/Startup.cs
+++ b/EvidenceApi/Startup.cs
@@ -205,7 +205,6 @@ namespace EvidenceApi
                 }
             });
 
-            //allow legacy Postgres behaviour
             AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
             app.UseSwagger();

--- a/EvidenceApi/V1/Gateways/EvidenceGateway.cs
+++ b/EvidenceApi/V1/Gateways/EvidenceGateway.cs
@@ -113,7 +113,7 @@ namespace EvidenceApi.V1.Gateways
                 .ToList();
         }
 
-        public DocumentSubmissionQueryResponse GetPaginatedDocumentSubmissionsByResidentId(Guid id, int? limit = 10,
+        public DocumentSubmissionQueryResponse GetPaginatedDocumentSubmissionsByResidentId(Guid id, string team, int? limit = 10,
             int? page = 1)
         {
             var offset = (limit * page) - limit;
@@ -122,7 +122,7 @@ namespace EvidenceApi.V1.Gateways
                 .Count(x => x.ResidentId.Equals(id));
 
             var documentSubmissions = _databaseContext.DocumentSubmissions
-                .Where(x => x.ResidentId.Equals(id))
+                .Where(x => x.ResidentId.Equals(id) && x.Team.Equals(team))
                 .Skip(offset ?? 0)
                 .Take(limit ?? 10)
                 .OrderByDescending(x => x.CreatedAt)

--- a/EvidenceApi/V1/Gateways/Interfaces/IEvidenceGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IEvidenceGateway.cs
@@ -19,7 +19,7 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         List<EvidenceRequest> FindEvidenceRequestsByResidentId(Guid id);
         List<EvidenceRequest> GetAll();
         List<EvidenceRequest> GetEvidenceRequests(ResidentSearchQuery request);
-        DocumentSubmissionQueryResponse GetPaginatedDocumentSubmissionsByResidentId(Guid id, int? pageSize,
+        DocumentSubmissionQueryResponse GetPaginatedDocumentSubmissionsByResidentId(Guid id, string team, int? pageSize,
             int? page);
     }
 }

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -31,7 +31,7 @@ namespace EvidenceApi.V1.UseCase
             ValidateRequest(request);
 
             var query =
-                _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request?.PageSize, request?.Page);
+                _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request.Team, request?.PageSize, request?.Page);
 
             var result = new DocumentSubmissionResponseObject { Total = query.Total, DocumentSubmissions = new List<DocumentSubmissionResponse>() };
 


### PR DESCRIPTION
## Link to JIRA ticket

(https://hackney.atlassian.net/jira/software/c/projects/DOC/boards/68?modal=detail&selectedIssue=DOC-1372)

## Describe this PR

Currently the pagination use case does not take into account the team from the request, instead returning all records by resident id. Modify the use case and evidence gateway so that the team is used in the where clause.


### *What changes have we introduced*

Add an additional where clause to the gateway query. Modify unit tests to test for this additional parameter.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
