### PR TITLE
Fix env vars loading correctly

### DIFF
--- a/EvidenceApi/Startup.cs
+++ b/EvidenceApi/Startup.cs
@@ -132,7 +132,7 @@ namespace EvidenceApi
                     c.IncludeXmlComments(xmlPath);
             });
 
-            DotEnv.Load();
+            DotEnv.Fluent().WithExceptions().WithEnvFiles(Path.Combine(Directory.GetCurrentDirectory(), "../.env")).Load();
 
             var options = AppOptions.FromEnv();
             services.AddSingleton(x => options);


### PR DESCRIPTION
Env vars were not loading correctly causing the API to respond with 500 locally when making requests to it.