### PR TITLE
Add user updated by value for internally submitted documents

### DIFF
--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
@@ -95,7 +95,8 @@ namespace EvidenceApi.V1.UseCase
                 AcceptedAt = currentDateTime,
                 Team = request.Team,
                 ResidentId = request.ResidentId,
-                StaffSelectedDocumentTypeId = request.StaffSelectedDocumentTypeId
+                StaffSelectedDocumentTypeId = request.StaffSelectedDocumentTypeId,
+                UserUpdatedBy = request.UserCreatedBy
             };
             return documentSubmission;
         }


### PR DESCRIPTION
## Link to JIRA ticket

[DOC-1375](https://hackney.atlassian.net/browse/DOC-1375)

## Describe this PR

When uploading a document on behalf of, documents are auto-approved. The uploading user isn't however saved as the approver. This PR addresses that.

### *What is the problem we're trying to solve*

Data (email) is already coming into the API. Documents already uploaded on behalf of will still have an empty approver.

### *What changes have we introduced*

Single line change.

#### _Checklist_

- [-] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [-] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [-] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check in staging