### PR TITLE
DOC-1376 - Adjust Search To Allow Searching For Residents Without Related Document Submissions / Evidence Requests

### DIFF
--- a/EvidenceApi.Tests/V1/UseCase/FindResidentsBySearchQueryUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/FindResidentsBySearchQueryUseCaseTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using AutoFixture;
 using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Domain;
@@ -60,7 +62,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             var result = _classUnderTest.Execute(request);
 
             // Assert
-            result.Count.Should().Be(1);
+            result.Count.Should().Be(2);
             var resultResident = result.Find(r => r.Name == "TestResident");
             resultResident.Should().NotBeNull();
             resultResident.Id.Should().Be(resident1.Id);

--- a/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
@@ -22,12 +22,13 @@ namespace EvidenceApi.V1.UseCase
         public List<ResidentResponse> Execute(ResidentSearchQuery request)
         {
             var residents = new List<ResidentResponse>();
-            findByResidentDetails(request, residents);
-            findByResidentReferenceId(request, residents);
+            FindByResidentDetails(request, residents);
+            FindResidentsWithNoAttachedRequests(request, residents);
+            FindByResidentReferenceId(request, residents);
             return residents;
         }
 
-        private void findByResidentDetails(ResidentSearchQuery request, ICollection<ResidentResponse> residents)
+        private void FindByResidentDetails(ResidentSearchQuery request, ICollection<ResidentResponse> residents)
         {
             var residentsForSearchQuery = _residentsGateway.FindResidents(request.SearchQuery);
 
@@ -47,7 +48,7 @@ namespace EvidenceApi.V1.UseCase
             }
         }
 
-        private void findByResidentReferenceId(ResidentSearchQuery request, ICollection<ResidentResponse> residents)
+        private void FindByResidentReferenceId(ResidentSearchQuery request, ICollection<ResidentResponse> residents)
         {
             var evidenceRequestsForTeamAndSearchQuery = _evidenceGateway.GetEvidenceRequests(request);
             if (evidenceRequestsForTeamAndSearchQuery.Count > 0)
@@ -56,6 +57,20 @@ namespace EvidenceApi.V1.UseCase
                 var residentForTeamAndSearchQuery = _residentsGateway.FindResident(evidenceRequest.ResidentId);
                 residents.Add(residentForTeamAndSearchQuery.ToResponse(evidenceRequest.ResidentReferenceId));
             }
+        }
+
+        private void FindResidentsWithNoAttachedRequests(ResidentSearchQuery request,
+            ICollection<ResidentResponse> residents)
+        {
+            var residentsForSearchQuery = _residentsGateway.FindResidents(request.SearchQuery);
+
+
+            foreach (var resident in residentsForSearchQuery)
+            {
+                //should the resident object have a team property? Otherwise we will return residents created by all teams...
+                //or is this what we want?
+                residents.Add(resident.ToResponse());
+            };
         }
     }
 }

--- a/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
@@ -67,7 +67,6 @@ namespace EvidenceApi.V1.UseCase
         {
             var residentsForSearchQuery = _residentsGateway.FindResidents(request.SearchQuery);
 
-
             foreach (var resident in residentsForSearchQuery)
             {
                 residents.Add(resident.ToResponse());

--- a/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
@@ -68,7 +68,7 @@ namespace EvidenceApi.V1.UseCase
             foreach (var resident in residentsForSearchQuery)
             {
                 //should the resident object have a team property? Otherwise we will return residents created by all teams...
-                //or is this what we want?
+                //or is this what we want?  I think it's what we want.
                 residents.Add(resident.ToResponse());
             };
         }

--- a/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindResidentsBySearchQueryUseCase.cs
@@ -25,7 +25,10 @@ namespace EvidenceApi.V1.UseCase
             FindByResidentDetails(request, residents);
             FindResidentsWithNoAttachedRequests(request, residents);
             FindByResidentReferenceId(request, residents);
-            return residents;
+
+            var uniqueResidents = residents.GroupBy(x => x.Id).Select(y => y.First());
+
+            return uniqueResidents.ToList();
         }
 
         private void FindByResidentDetails(ResidentSearchQuery request, ICollection<ResidentResponse> residents)
@@ -67,8 +70,6 @@ namespace EvidenceApi.V1.UseCase
 
             foreach (var resident in residentsForSearchQuery)
             {
-                //should the resident object have a team property? Otherwise we will return residents created by all teams...
-                //or is this what we want?  I think it's what we want.
                 residents.Add(resident.ToResponse());
             };
         }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/c/projects/DOC/boards/68?modal=detail&selectedIssue=DOC-1376

## Describe this PR

This alters the resident search use case to allow for residents who do not have a linked evidence request.

### *What changes have we introduced*

Modified the resident search use case.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly
