### PR TITLE
DOC-1395 - Create Table To Link Resident Ids and Group Ids

### DIFF
--- a/EvidenceApi/Migrations/20230123150743_createResidentGroupIdMetaTable.Designer.cs
+++ b/EvidenceApi/Migrations/20230123150743_createResidentGroupIdMetaTable.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using EvidenceApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EvidenceApi.Migrations
 {
     [DbContext(typeof(EvidenceContext))]
-    partial class EvidenceContextModelSnapshot : ModelSnapshot
+    [Migration("20230123150743_createResidentGroupIdMetaTable")]
+    partial class createResidentGroupIdMetaTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EvidenceApi/Migrations/20230123150743_createResidentGroupIdMetaTable.cs
+++ b/EvidenceApi/Migrations/20230123150743_createResidentGroupIdMetaTable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/EvidenceApi/Migrations/20230123150743_createResidentGroupIdMetaTable.cs
+++ b/EvidenceApi/Migrations/20230123150743_createResidentGroupIdMetaTable.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EvidenceApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class createResidentGroupIdMetaTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "residents_team_group_id",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    residentid = table.Column<Guid>(name: "resident_id", type: "uuid", nullable: false),
+                    team = table.Column<string>(type: "text", nullable: true),
+                    groupid = table.Column<Guid>(name: "group_id", type: "uuid", nullable: true),
+                    createdat = table.Column<DateTime>(name: "created_at", type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_residents_team_group_id", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_residents_team_group_id_residents_resident_id",
+                        column: x => x.residentid,
+                        principalTable: "residents",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_residents_team_group_id_resident_id",
+                table: "residents_team_group_id",
+                column: "resident_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "residents_team_group_id");
+        }
+    }
+}

--- a/EvidenceApi/V1/Domain/ResidentsTeamGroupId.cs
+++ b/EvidenceApi/V1/Domain/ResidentsTeamGroupId.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using EvidenceApi.V1.Infrastructure.Interfaces;
+
+namespace EvidenceApi.V1.Domain;
+
+[Table("residents_team_group_id")]
+public class ResidentsTeamGroupId: IEntity
+{
+    [Required]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Column("resident_id")]
+    [ForeignKey("Resident")]
+    public Guid ResidentId { get; set; }
+
+    [ForeignKey("ResidentId")]
+    public virtual Resident Resident { get; set; }
+
+    [Column("team")]
+    public string Team { get; set; }
+
+    [Column("group_id")]
+    public Guid? GroupId { get; set; } = null;
+
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+}

--- a/EvidenceApi/V1/Domain/ResidentsTeamGroupId.cs
+++ b/EvidenceApi/V1/Domain/ResidentsTeamGroupId.cs
@@ -6,7 +6,7 @@ using EvidenceApi.V1.Infrastructure.Interfaces;
 namespace EvidenceApi.V1.Domain;
 
 [Table("residents_team_group_id")]
-public class ResidentsTeamGroupId: IEntity
+public class ResidentsTeamGroupId : IEntity
 {
     [Required]
     [Column("id")]

--- a/EvidenceApi/V1/Infrastructure/EvidenceContext.cs
+++ b/EvidenceApi/V1/Infrastructure/EvidenceContext.cs
@@ -19,6 +19,8 @@ namespace EvidenceApi.V1.Infrastructure
         public DbSet<Communication> Communications { get; set; }
         public DbSet<DocumentSubmission> DocumentSubmissions { get; set; }
 
+        public DbSet<ResidentsTeamGroupId> ResidentsTeamGroupId { get; set; }
+
         public override int SaveChanges()
         {
             var entries = ChangeTracker


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/c/projects/DOC/boards/68?modal=detail&selectedIssue=DOC-1395

## Describe this PR

This PR creates a new table, used to associate resident_ids and group_ids.

### *What changes have we introduced*

Added new table to associate residents and group ids. NB this table also includes a 'created_at' column in order to conform to the IEntity Interface used by the other database tables.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly
