### PR TITLE
DOC-1399 - Refactor to Fetch Claims By Group Id

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -26,9 +26,11 @@ namespace EvidenceApi.Tests.V1.E2ETests
         private readonly Guid _id = Guid.NewGuid();
         private readonly Guid _groupId = Guid.NewGuid();
 
+
         [SetUp]
         public void SetUp()
         {
+            DatabaseContext.ChangeTracker.Clear();
 
             _document = _fixture.Build<Document>()
                 .With(x => x.Id, _id)
@@ -230,7 +232,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             var resident = TestDataHelper.ResidentWithId(Guid.NewGuid());
 
-
             var residentTeamGroupId = new ResidentsTeamGroupId() { Resident = resident, GroupId = _groupId, Team = "Development Housing Team" };
 
             var evidenceRequestId = Guid.NewGuid();
@@ -250,8 +251,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             DatabaseContext.DocumentSubmissions.Add(documentSubmission1);
             DatabaseContext.SaveChanges();
-
-
 
             var uri = new Uri($"api/v1/document_submissions?team=Development+Housing+Team&residentId={documentSubmission1.ResidentId}", UriKind.Relative);
 

--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -54,7 +54,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                 )
             );
 
-            DocumentsApiServer.Given(Request.Create().WithParam("groupId", _groupId.ToString()).UsingGet())
+            DocumentsApiServer.Given(Request.Create().WithParam("groupId", _groupId.ToString()).WithParam("limit", "5000").UsingGet())
                 .RespondWith(Response.Create().WithStatusCode(200).WithBody(JsonConvert.SerializeObject(_paginatedClaimResponse)));
 
             DocumentsApiServer.Given(

--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -27,7 +27,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
         private readonly Guid _id = Guid.NewGuid();
         private readonly Guid _groupId = Guid.NewGuid();
 
-
         [SetUp]
         public void SetUp()
         {
@@ -280,13 +279,14 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var residentId = Guid.NewGuid();
             var resident = TestDataHelper.ResidentWithId(residentId);
             var currentDate = new DateTime();
+            var team = "Development Housing Team";
 
-            var residentTeamGroupId = new ResidentsTeamGroupId() { GroupId = _groupId, Resident = resident, Team = "Development Housing Team" };
+            var residentTeamGroupId = new ResidentsTeamGroupId() { GroupId = _groupId, Resident = resident, Team = team };
 
             var evidenceRequestId = Guid.NewGuid();
             var evidenceRequest = TestDataHelper.EvidenceRequest();
             evidenceRequest.Id = evidenceRequestId;
-            evidenceRequest.Team = "Development Housing Team";
+            evidenceRequest.Team = team;
 
             DatabaseContext.EvidenceRequests.Add(evidenceRequest);
             DatabaseContext.Residents.Add(resident);
@@ -298,27 +298,12 @@ namespace EvidenceApi.Tests.V1.E2ETests
             documentSubmission1.State = SubmissionState.Approved;
             documentSubmission1.CreatedAt = currentDate.AddDays(1);
             documentSubmission1.ClaimId = _createdClaim.Id.ToString();
-            var documentSubmission2 = TestDataHelper.DocumentSubmissionWithResidentId(residentId, evidenceRequest);
-            documentSubmission2.State = SubmissionState.Approved;
-            documentSubmission2.CreatedAt = currentDate.AddDays(2);
-            documentSubmission2.ClaimId = _createdClaim.Id.ToString();
-            var documentSubmission3 = TestDataHelper.DocumentSubmissionWithResidentId(residentId, evidenceRequest);
-            documentSubmission3.State = SubmissionState.Pending;
-            documentSubmission3.CreatedAt = currentDate.AddDays(3);
-            documentSubmission3.ClaimId = _createdClaim.Id.ToString();
-            var documentSubmission4 = TestDataHelper.DocumentSubmissionWithResidentId(residentId, evidenceRequest);
-            documentSubmission4.State = SubmissionState.Approved;
-            documentSubmission3.CreatedAt = currentDate.AddDays(4);
-            documentSubmission4.ClaimId = _createdClaim.Id.ToString();
 
             DatabaseContext.DocumentSubmissions.Add(documentSubmission1);
-            DatabaseContext.DocumentSubmissions.Add(documentSubmission2);
-            DatabaseContext.DocumentSubmissions.Add(documentSubmission3);
-            DatabaseContext.DocumentSubmissions.Add(documentSubmission4);
 
             DatabaseContext.SaveChanges();
 
-            var uri = new Uri($"api/v1/document_submissions?team=Development+Housing+Team&residentId={residentId}&state=Approved&pageSize=2", UriKind.Relative);
+            var uri = new Uri($"api/v1/document_submissions?team=Development+Housing+Team&residentId={residentId}&state=Approved", UriKind.Relative);
 
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
@@ -328,10 +313,10 @@ namespace EvidenceApi.Tests.V1.E2ETests
             {
                 DocumentSubmissions = new List<DocumentSubmissionResponse>()
                 {
-                    documentSubmission4.ToResponse(null, documentSubmission4.EvidenceRequestId, null, null, _createdClaim),
-                    documentSubmission2.ToResponse(null, documentSubmission2.EvidenceRequestId, null, null, _createdClaim)
+                    documentSubmission1.ToResponse(null, documentSubmission1.EvidenceRequestId, null, null, _createdClaim),
+
                     },
-                Total = 3
+                Total = 1
             };
             response.StatusCode.Should().Be(200);
             result.Should().BeEquivalentTo(expected);

--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -266,6 +266,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             var resident = TestDataHelper.ResidentWithId(residentId);
             var currentDate = new DateTime();
 
+            var residentTeamGroupId = new ResidentsTeamGroupId() { GroupId = Guid.NewGuid(), Resident = resident };
 
             var evidenceRequestId = Guid.NewGuid();
             var evidenceRequest = TestDataHelper.EvidenceRequest();
@@ -274,6 +275,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             DatabaseContext.EvidenceRequests.Add(evidenceRequest);
             DatabaseContext.Residents.Add(resident);
+            DatabaseContext.ResidentsTeamGroupId.Add(residentTeamGroupId);
 
             DatabaseContext.SaveChanges();
 

--- a/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/DocumentSubmissionsTest.cs
@@ -21,6 +21,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
     {
         private readonly IFixture _fixture = new Fixture();
         private Claim _createdClaim;
+        private PaginatedClaimResponse _paginatedClaimResponse;
         private Document _document;
         private S3UploadPolicy _createdUploadPolicy;
         private readonly Guid _id = Guid.NewGuid();
@@ -43,6 +44,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
 
             _createdUploadPolicy = _fixture.Create<S3UploadPolicy>();
 
+            _paginatedClaimResponse = new PaginatedClaimResponse() { Claims = new List<Claim>() { _createdClaim } };
+
             DocumentsApiServer.Given(
                 Request.Create().WithPath($"/api/v1/claims/{_createdClaim.Id}").UsingGet()
             ).RespondWith(
@@ -52,8 +55,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             );
 
             DocumentsApiServer.Given(Request.Create().WithParam("groupId", _groupId.ToString()).UsingGet())
-                .RespondWith(Response.Create().WithStatusCode(200).WithBody(JsonConvert.SerializeObject(new List<Claim>() {
-                _createdClaim})));
+                .RespondWith(Response.Create().WithStatusCode(200).WithBody(JsonConvert.SerializeObject(_paginatedClaimResponse)));
 
             DocumentsApiServer.Given(
                 Request.Create().WithPath("/api/v1/claims")

--- a/EvidenceApi.Tests/V1/Gateways/DocumentsApiGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/DocumentsApiGatewayTests.cs
@@ -116,6 +116,31 @@ namespace EvidenceApi.Tests.V1.Gateways
         }
 
         [Test]
+        public async Task CanGetClaimsByGroupId()
+        {
+            var groupId = Guid.NewGuid();
+            var claimOne = _fixture.Create<Claim>();
+            var claimTwo = _fixture.Create<Claim>();
+            var claimThree = _fixture.Create<Claim>();
+            claimOne.GroupId = groupId;
+            claimTwo.GroupId = groupId;
+            claimThree.GroupId = groupId;
+
+            var claimsList = new List<Claim>() { claimOne, claimTwo, claimThree };
+
+            _messageHandler.SetupRequest(HttpMethod.Get,
+                    $"{_options.DocumentsApiUrl}api/v1/claims?groupId={groupId}",
+                    request => request.Headers.Authorization.ToString() == _options.DocumentsApiGetClaimsToken)
+                .ReturnsResponse(HttpStatusCode.OK, JsonConvert.SerializeObject(claimsList), "application/json");
+
+            var result = await _classUnderTest.GetClaimsByGroupId(groupId);
+
+            result.Should().BeEquivalentTo(claimsList);
+
+
+        }
+
+        [Test]
         public void ShouldThrowWhenGettingClaimsByIdsFails()
         {
             void AddClaimResponse(Guid claimId, HttpStatusCode status, string body)

--- a/EvidenceApi.Tests/V1/Gateways/DocumentsApiGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/DocumentsApiGatewayTests.cs
@@ -133,7 +133,7 @@ namespace EvidenceApi.Tests.V1.Gateways
             var paginatedClaimsResponse = new PaginatedClaimResponse() { Claims = claimsList };
 
             _messageHandler.SetupRequest(HttpMethod.Get,
-                    $"{_options.DocumentsApiUrl}api/v1/claims?groupId={groupId}",
+                    $"{_options.DocumentsApiUrl}api/v1/claims?groupId={groupId}&limit=5000",
                     request => request.Headers.Authorization.ToString() == _options.DocumentsApiGetClaimsToken)
                 .ReturnsResponse(HttpStatusCode.OK, JsonConvert.SerializeObject(paginatedClaimsResponse), "application/json");
 

--- a/EvidenceApi.Tests/V1/Gateways/DocumentsApiGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/DocumentsApiGatewayTests.cs
@@ -126,6 +126,8 @@ namespace EvidenceApi.Tests.V1.Gateways
             claimTwo.GroupId = groupId;
             claimThree.GroupId = groupId;
 
+            var request = new PaginatedClaimRequest() { GroupId = groupId };
+
             var claimsList = new List<Claim>() { claimOne, claimTwo, claimThree };
 
             var paginatedClaimsResponse = new PaginatedClaimResponse() { Claims = claimsList };
@@ -135,7 +137,7 @@ namespace EvidenceApi.Tests.V1.Gateways
                     request => request.Headers.Authorization.ToString() == _options.DocumentsApiGetClaimsToken)
                 .ReturnsResponse(HttpStatusCode.OK, JsonConvert.SerializeObject(paginatedClaimsResponse), "application/json");
 
-            var result = await _classUnderTest.GetClaimsByGroupId(groupId);
+            var result = await _classUnderTest.GetClaimsByGroupId(request);
 
             result.Claims.Should().BeEquivalentTo(claimsList);
 

--- a/EvidenceApi.Tests/V1/Gateways/DocumentsApiGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/DocumentsApiGatewayTests.cs
@@ -128,14 +128,16 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             var claimsList = new List<Claim>() { claimOne, claimTwo, claimThree };
 
+            var paginatedClaimsResponse = new PaginatedClaimResponse() { Claims = claimsList };
+
             _messageHandler.SetupRequest(HttpMethod.Get,
                     $"{_options.DocumentsApiUrl}api/v1/claims?groupId={groupId}",
                     request => request.Headers.Authorization.ToString() == _options.DocumentsApiGetClaimsToken)
-                .ReturnsResponse(HttpStatusCode.OK, JsonConvert.SerializeObject(claimsList), "application/json");
+                .ReturnsResponse(HttpStatusCode.OK, JsonConvert.SerializeObject(paginatedClaimsResponse), "application/json");
 
             var result = await _classUnderTest.GetClaimsByGroupId(groupId);
 
-            result.Should().BeEquivalentTo(claimsList);
+            result.Claims.Should().BeEquivalentTo(claimsList);
 
 
         }

--- a/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using AutoFixture;
+using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Domain;
 using EvidenceApi.V1.Gateways;
 using FluentAssertions;
@@ -298,6 +299,25 @@ namespace EvidenceApi.Tests.V1.Gateways
             foundRecord.Id.Should().NotBeEmpty();
             foundRecord.Resident.Should().Be(request);
 
+        }
+
+        [Test]
+        public void GetGroupIdByResidentIdAndTeamReturnsGroupId()
+        {
+            var request = _fixture.Create<DocumentSubmissionSearchQuery>();
+            var resident = _fixture.Create<Resident>();
+            var groupId = Guid.NewGuid();
+
+            request.ResidentId = resident.Id;
+
+            var testEntry = new ResidentsTeamGroupId() { Resident = resident, GroupId = groupId, Team = request.Team};
+
+            DatabaseContext.ResidentsTeamGroupId.Add(testEntry);
+            DatabaseContext.SaveChanges();
+
+            var result = _classUnderTest.GetGroupIdByResidentIdAndTeam(request);
+
+            result.Should().Be(groupId);
         }
 
         [Test]

--- a/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
@@ -352,25 +352,6 @@ namespace EvidenceApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetGroupIdByResidentIdAndTeamReturnsGroupId()
-        {
-            var request = _fixture.Create<DocumentSubmissionSearchQuery>();
-            var resident = _fixture.Create<Resident>();
-            var groupId = Guid.NewGuid();
-
-            request.ResidentId = resident.Id;
-
-            var testEntry = new ResidentsTeamGroupId() { Resident = resident, GroupId = groupId, Team = request.Team };
-
-            DatabaseContext.ResidentsTeamGroupId.Add(testEntry);
-            DatabaseContext.SaveChanges();
-
-            var result = _classUnderTest.GetGroupIdByResidentIdAndTeam(request);
-
-            result.Should().Be(groupId);
-        }
-
-        [Test]
         public void GetAllResidentIdsAndGroupIdsByFirstCharacter()
         {
             var currentDate = new DateTime();

--- a/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
@@ -310,7 +310,7 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             request.ResidentId = resident.Id;
 
-            var testEntry = new ResidentsTeamGroupId() { Resident = resident, GroupId = groupId, Team = request.Team};
+            var testEntry = new ResidentsTeamGroupId() { Resident = resident, GroupId = groupId, Team = request.Team };
 
             DatabaseContext.ResidentsTeamGroupId.Add(testEntry);
             DatabaseContext.SaveChanges();

--- a/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
@@ -325,11 +325,11 @@ namespace EvidenceApi.Tests.V1.Gateways
         {
             var currentDate = new DateTime();
             var residentOne = _fixture.Create<Resident>();
-            var groupIdOne = Guid.NewGuid();
+            var groupIdOne = new Guid("38703a76-3af6-48f5-aa1b-188679400136");
             var residentTwo = _fixture.Create<Resident>();
-            var groupIdTwo = Guid.NewGuid();
+            var groupIdTwo = new Guid("48703a76-3af6-48f5-aa1b-188679400136");
             var residentThree = _fixture.Create<Resident>();
-            var groupIdThree = Guid.NewGuid();
+            var groupIdThree = new Guid("58703a76-3af6-48f5-aa1b-188679400136");
 
             var guidCharacter = groupIdOne.ToString().First();
 

--- a/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCaseTests.cs
@@ -21,6 +21,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         private Mock<IEvidenceGateway> _evidenceGateway;
         private Mock<IDocumentTypeGateway> _documentTypesGateway;
         private Mock<IStaffSelectedDocumentTypeGateway> _staffSelectedDocumentTypeGateway;
+        private Mock<IResidentsGateway> _residentsGateway;
         private Mock<IDocumentsApiGateway> _documentsApiGateway;
         private readonly IFixture _fixture = new Fixture();
         private DocumentType _documentType;
@@ -43,11 +44,13 @@ namespace EvidenceApi.Tests.V1.UseCase
             _documentTypesGateway = new Mock<IDocumentTypeGateway>();
             _staffSelectedDocumentTypeGateway = new Mock<IStaffSelectedDocumentTypeGateway>();
             _documentsApiGateway = new Mock<IDocumentsApiGateway>();
+            _residentsGateway = new Mock<IResidentsGateway>();
             _classUnderTest = new FindDocumentSubmissionsByResidentIdUseCase(
                 _evidenceGateway.Object,
                 _documentTypesGateway.Object,
                 _staffSelectedDocumentTypeGateway.Object,
-                _documentsApiGateway.Object
+                _documentsApiGateway.Object,
+                _residentsGateway.Object
             );
         }
 

--- a/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCaseTests.cs
@@ -187,7 +187,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             _evidenceGateway
                 .Setup(x => x.GetPaginatedDocumentSubmissionsByResidentId(It.IsAny<Guid>(), It.IsAny<SubmissionState?>(), It.IsAny<int?>(),
                     It.IsAny<int?>())).Returns(_injectedResult);
-            _documentsApiGateway.Setup(x => x.GetClaimsByGroupId(It.IsAny<Guid>())).ReturnsAsync(paginatedClaimsResponse);
+            _documentsApiGateway.Setup(x => x.GetClaimsByGroupId(It.IsAny<PaginatedClaimRequest>())).ReturnsAsync(paginatedClaimsResponse);
             _documentsApiGateway.Setup(x => x.GetClaimsByIdsThrottled(claimsIds)).ReturnsAsync(claimsList);
         }
     }

--- a/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCaseTests.cs
@@ -175,6 +175,11 @@ namespace EvidenceApi.Tests.V1.UseCase
             claimsList.Add(_fixture.Create<Claim>());
             claimsList.Add(_fixture.Create<Claim>());
 
+            var paginatedClaimsResponse = new PaginatedClaimResponse()
+            {
+                Claims = new List<Claim>() { _claim1.Result, _claim2.Result }
+            };
+
             _documentTypesGateway.Setup(x => x.GetDocumentTypeByTeamNameAndDocumentTypeId(It.IsAny<string>(), It.IsAny<string>())).Returns(_documentType);
             _residentsGateway.Setup(x => x.GetGroupIdByResidentIdAndTeam(It.IsAny<DocumentSubmissionSearchQuery>()))
                 .Returns(_residentsTeamGroupId.GroupId);
@@ -182,10 +187,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             _evidenceGateway
                 .Setup(x => x.GetPaginatedDocumentSubmissionsByResidentId(It.IsAny<Guid>(), It.IsAny<SubmissionState?>(), It.IsAny<int?>(),
                     It.IsAny<int?>())).Returns(_injectedResult);
-            _documentsApiGateway.Setup(x => x.GetClaimsByGroupId(It.IsAny<Guid>())).ReturnsAsync(new List<Claim>()
-            {
-                _claim1.Result, _claim2.Result
-            });
+            _documentsApiGateway.Setup(x => x.GetClaimsByGroupId(It.IsAny<Guid>())).ReturnsAsync(paginatedClaimsResponse);
             _documentsApiGateway.Setup(x => x.GetClaimsByIdsThrottled(claimsIds)).ReturnsAsync(claimsList);
         }
     }

--- a/EvidenceApi/V1/Boundary/Request/PaginatedClaimRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/PaginatedClaimRequest.cs
@@ -1,0 +1,13 @@
+#nullable enable annotations
+using System;
+
+namespace EvidenceApi.V1.Boundary.Request
+{
+    public class PaginatedClaimRequest
+    {
+        public Guid GroupId { get; set; }
+        public int? Limit { get; set; }
+        public string? Before { get; set; } = null; // base64URL
+        public string? After { get; set; } = null; // base64URL
+    }
+}

--- a/EvidenceApi/V1/Domain/PaginatedClaimResponse.cs
+++ b/EvidenceApi/V1/Domain/PaginatedClaimResponse.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace EvidenceApi.V1.Domain
+{
+    public class PaginatedClaimResponse
+    {
+        public List<Claim> Claims { get; set; }
+        public Paging Paging { get; set; }
+    }
+
+    public class Paging
+    {
+        public Cursors Cursors { get; set; } = null;
+        public bool HasBefore { get; set; }
+        public bool HasAfter { get; set; }
+    }
+
+    public class Cursors
+    {
+        public string Before { get; set; } = null;
+        public string After { get; set; } = null;
+    }
+}

--- a/EvidenceApi/V1/Domain/ResidentsTeamGroupId.cs
+++ b/EvidenceApi/V1/Domain/ResidentsTeamGroupId.cs
@@ -23,7 +23,7 @@ public class ResidentsTeamGroupId : IEntity
     public string Team { get; set; }
 
     [Column("group_id")]
-    public Guid? GroupId { get; set; } = null;
+    public Guid GroupId { get; set; }
 
     [Column("created_at")]
     public DateTime CreatedAt { get; set; }

--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -150,22 +150,10 @@ namespace EvidenceApi.V1.Gateways
 
         public async Task<PaginatedClaimResponse> GetClaimsByGroupId(PaginatedClaimRequest request)
         {
-            var builtQuery = $"groupId={request.GroupId}";
-
-            if (request.Limit != null)
-            {
-                builtQuery += $"&limit={request.Limit}";
-            }
-
-            if (request.Before != null)
-            {
-                builtQuery += $"&before={request.Before}";
-            }
-
-            if (request.After != null)
-            {
-                builtQuery += $"&after={request.After}";
-            }
+            var builtQuery = $"groupId={request.GroupId}" +
+                             (request.Limit != null ? $"&limit={request.Limit}" : string.Empty) +
+                             (request.Before != null ? $"&before={request.Before}" : string.Empty) +
+                             (request.After != null ? $"&after={request.After}" : string.Empty);
 
             var uri = new Uri($"api/v1/claims?{builtQuery}" + request.After, UriKind.Relative);
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiGetClaimsToken);

--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -149,6 +149,18 @@ namespace EvidenceApi.V1.Gateways
             return await DeserializeResponse<S3UploadPolicy>(response).ConfigureAwait(true);
         }
 
+        public async Task<List<Claim>> GetClaimsByGroupId(Guid groupId)
+        {
+            var uri = new Uri($"api/v1/claims?groupId={groupId}", UriKind.Relative);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiGetClaimsToken);
+            var response = await _client.GetAsync(uri).ConfigureAwait(true);
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw new DocumentsApiException($"Incorrect status code returned: {response.StatusCode}");
+            }
+            return await DeserializeResponse<List<Claim>>(response).ConfigureAwait(true);
+        }
+
         private static StringContent SerializeBackfillRequest(GroupResidentIdClaimIdBackfillObject request)
         {
             var updateRequest = new ClaimUpdateRequest() { GroupId = request.GroupId };

--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -14,6 +14,7 @@ using EvidenceApi.V1.Domain;
 using System.Net.Http.Headers;
 using EvidenceApi.V1.Boundary.Response;
 using EvidenceApi.V1.Boundary.Response.Exceptions;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace EvidenceApi.V1.Gateways
 {
@@ -150,7 +151,7 @@ namespace EvidenceApi.V1.Gateways
 
         public async Task<PaginatedClaimResponse> GetClaimsByGroupId(PaginatedClaimRequest request)
         {
-            var uri = new Uri($"api/v1/claims?groupId={request.GroupId}&limit=5000" + request.After, UriKind.Relative);
+            var uri = new Uri($"api/v1/claims?groupId={request.GroupId}&limit=5000", UriKind.Relative);
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiGetClaimsToken);
             var response = await _client.GetAsync(uri).ConfigureAwait(true);
             if (response.StatusCode != HttpStatusCode.OK)

--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -150,12 +150,7 @@ namespace EvidenceApi.V1.Gateways
 
         public async Task<PaginatedClaimResponse> GetClaimsByGroupId(PaginatedClaimRequest request)
         {
-            var builtQuery = $"groupId={request.GroupId}" +
-                             (request.Limit != null ? $"&limit={request.Limit}" : string.Empty) +
-                             (request.Before != null ? $"&before={request.Before}" : string.Empty) +
-                             (request.After != null ? $"&after={request.After}" : string.Empty);
-
-            var uri = new Uri($"api/v1/claims?{builtQuery}" + request.After, UriKind.Relative);
+            var uri = new Uri($"api/v1/claims?groupId={request.GroupId}&limit=5000" + request.After, UriKind.Relative);
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiGetClaimsToken);
             var response = await _client.GetAsync(uri).ConfigureAwait(true);
             if (response.StatusCode != HttpStatusCode.OK)

--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using EvidenceApi.V1.Domain;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
 using EvidenceApi.V1.Boundary.Response;
 using EvidenceApi.V1.Boundary.Response.Exceptions;
 
@@ -149,7 +148,7 @@ namespace EvidenceApi.V1.Gateways
             return await DeserializeResponse<S3UploadPolicy>(response).ConfigureAwait(true);
         }
 
-        public async Task<List<Claim>> GetClaimsByGroupId(Guid groupId)
+        public async Task<PaginatedClaimResponse> GetClaimsByGroupId(Guid groupId)
         {
             var uri = new Uri($"api/v1/claims?groupId={groupId}", UriKind.Relative);
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiGetClaimsToken);
@@ -158,7 +157,7 @@ namespace EvidenceApi.V1.Gateways
             {
                 throw new DocumentsApiException($"Incorrect status code returned: {response.StatusCode}");
             }
-            return await DeserializeResponse<List<Claim>>(response).ConfigureAwait(true);
+            return await DeserializeResponse<PaginatedClaimResponse>(response).ConfigureAwait(true);
         }
 
         private static StringContent SerializeBackfillRequest(GroupResidentIdClaimIdBackfillObject request)

--- a/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/DocumentsApiGateway.cs
@@ -148,9 +148,26 @@ namespace EvidenceApi.V1.Gateways
             return await DeserializeResponse<S3UploadPolicy>(response).ConfigureAwait(true);
         }
 
-        public async Task<PaginatedClaimResponse> GetClaimsByGroupId(Guid groupId)
+        public async Task<PaginatedClaimResponse> GetClaimsByGroupId(PaginatedClaimRequest request)
         {
-            var uri = new Uri($"api/v1/claims?groupId={groupId}", UriKind.Relative);
+            var builtQuery = $"groupId={request.GroupId}";
+
+            if (request.Limit != null)
+            {
+                builtQuery += $"&limit={request.Limit}";
+            }
+
+            if (request.Before != null)
+            {
+                builtQuery += $"&before={request.Before}";
+            }
+
+            if (request.After != null)
+            {
+                builtQuery += $"&after={request.After}";
+            }
+
+            var uri = new Uri($"api/v1/claims?{builtQuery}" + request.After, UriKind.Relative);
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(_options.DocumentsApiGetClaimsToken);
             var response = await _client.GetAsync(uri).ConfigureAwait(true);
             if (response.StatusCode != HttpStatusCode.OK)

--- a/EvidenceApi/V1/Gateways/Interfaces/IDocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IDocumentsApiGateway.cs
@@ -15,6 +15,6 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         Task<List<Claim>> GetClaimsByIdsThrottled(List<string> claimIds);
         Task<S3UploadPolicy> CreateUploadPolicy(Guid id);
         Task<List<ClaimBackfillResponse>> BackfillClaimsWithGroupIds(List<GroupResidentIdClaimIdBackfillObject> backfillObjects);
-        Task<PaginatedClaimResponse> GetClaimsByGroupId(Guid groupId);
+        Task<PaginatedClaimResponse> GetClaimsByGroupId(PaginatedClaimRequest request);
     }
 }

--- a/EvidenceApi/V1/Gateways/Interfaces/IDocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IDocumentsApiGateway.cs
@@ -15,5 +15,6 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         Task<List<Claim>> GetClaimsByIdsThrottled(List<string> claimIds);
         Task<S3UploadPolicy> CreateUploadPolicy(Guid id);
         Task<List<ClaimBackfillResponse>> BackfillClaimsWithGroupIds(List<GroupResidentIdClaimIdBackfillObject> backfillObjects);
+        Task<List<Claim>> GetClaimsByGroupId(Guid groupId);
     }
 }

--- a/EvidenceApi/V1/Gateways/Interfaces/IDocumentsApiGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IDocumentsApiGateway.cs
@@ -15,6 +15,6 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         Task<List<Claim>> GetClaimsByIdsThrottled(List<string> claimIds);
         Task<S3UploadPolicy> CreateUploadPolicy(Guid id);
         Task<List<ClaimBackfillResponse>> BackfillClaimsWithGroupIds(List<GroupResidentIdClaimIdBackfillObject> backfillObjects);
-        Task<List<Claim>> GetClaimsByGroupId(Guid groupId);
+        Task<PaginatedClaimResponse> GetClaimsByGroupId(Guid groupId);
     }
 }

--- a/EvidenceApi/V1/Gateways/Interfaces/IResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IResidentsGateway.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Domain;
 
 namespace EvidenceApi.V1.Gateways.Interfaces
@@ -12,6 +13,7 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         List<Resident> FindResidents(string searchQuery);
         Resident CreateResident(Resident request);
         void AddResidentGroupId(Resident request);
+        Guid GetGroupIdByResidentIdAndTeam(DocumentSubmissionSearchQuery query);
         List<GroupResidentIdClaimIdBackfillObject> GetAllResidentIdsAndGroupIdsByFirstCharacter(char groupIdCharacter);
     }
 }

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -84,6 +84,7 @@ namespace EvidenceApi.V1.Gateways
             var queryResponse = _databaseContext.ResidentsTeamGroupId
                 .FirstOrDefault(x => x.ResidentId == query.ResidentId && x.Team == query.Team);
 
+            //error handling
             return queryResponse.GroupId;
         }
 

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -84,8 +84,7 @@ namespace EvidenceApi.V1.Gateways
             var queryResponse = _databaseContext.ResidentsTeamGroupId
                 .FirstOrDefault(x => x.ResidentId == query.ResidentId && x.Team == query.Team);
 
-            //error handling
-            return queryResponse.GroupId;
+           return queryResponse?.GroupId ?? Guid.Empty;
         }
 
         public List<GroupResidentIdClaimIdBackfillObject> GetAllResidentIdsAndGroupIdsByFirstCharacter(char groupIdCharacter)

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -92,14 +92,6 @@ namespace EvidenceApi.V1.Gateways
             return entity.GroupId;
         }
 
-        public Guid GetGroupIdByResidentIdAndTeam(DocumentSubmissionSearchQuery query)
-        {
-            var queryResponse = _databaseContext.ResidentsTeamGroupId
-                .FirstOrDefault(x => x.ResidentId == query.ResidentId && x.Team == query.Team);
-
-            return queryResponse?.GroupId ?? Guid.Empty;
-        }
-
         public List<GroupResidentIdClaimIdBackfillObject> GetAllResidentIdsAndGroupIdsByFirstCharacter(char groupIdCharacter)
 
         {

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -84,7 +84,7 @@ namespace EvidenceApi.V1.Gateways
             var queryResponse = _databaseContext.ResidentsTeamGroupId
                 .FirstOrDefault(x => x.ResidentId == query.ResidentId && x.Team == query.Team);
 
-           return queryResponse?.GroupId ?? Guid.Empty;
+            return queryResponse?.GroupId ?? Guid.Empty;
         }
 
         public List<GroupResidentIdClaimIdBackfillObject> GetAllResidentIdsAndGroupIdsByFirstCharacter(char groupIdCharacter)

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Domain;
 using EvidenceApi.V1.Gateways.Interfaces;
 using EvidenceApi.V1.Infrastructure;
@@ -76,6 +77,14 @@ namespace EvidenceApi.V1.Gateways
             _databaseContext.ResidentsTeamGroupId.Add(newEntry);
             _databaseContext.SaveChanges();
 
+        }
+
+        public Guid GetGroupIdByResidentIdAndTeam(DocumentSubmissionSearchQuery query)
+        {
+            var queryResponse = _databaseContext.ResidentsTeamGroupId
+                .FirstOrDefault(x => x.ResidentId == query.ResidentId && x.Team == query.Team);
+
+            return queryResponse.GroupId;
         }
 
         public List<GroupResidentIdClaimIdBackfillObject> GetAllResidentIdsAndGroupIdsByFirstCharacter(char groupIdCharacter)

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -9,6 +9,7 @@ using EvidenceApi.V1.Domain;
 using System.Threading.Tasks;
 using System;
 using System.Text;
+using System.Text.Json;
 
 namespace EvidenceApi.V1.UseCase
 {

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -8,6 +8,7 @@ using EvidenceApi.V1.UseCase.Interfaces;
 using EvidenceApi.V1.Domain;
 using System.Threading.Tasks;
 using System;
+using System.Text;
 
 namespace EvidenceApi.V1.UseCase
 {
@@ -38,23 +39,25 @@ namespace EvidenceApi.V1.UseCase
 
             var result = new DocumentSubmissionResponseObject { Total = query.Total, DocumentSubmissions = new List<DocumentSubmissionResponse>() };
 
-            //need to calculate pagination from query response
-
             var claimsRequest = new PaginatedClaimRequest() { GroupId = groupId };
 
             var claimsResponse = await _documentsApiGateway.GetClaimsByGroupId(claimsRequest);
 
-            var claimIndex = 0;
             foreach (var ds in query.DocumentSubmissions)
             {
+                var claim = FindClaim(claimsResponse.Claims, ds);
                 var documentType = FindDocumentType(ds.Team, ds.DocumentTypeId);
                 var staffSelectedDocumentType = FindStaffSelectedDocumentType(ds.Team,
                     ds.StaffSelectedDocumentTypeId);
-                result.DocumentSubmissions.Add(ds.ToResponse(documentType, ds.EvidenceRequestId, staffSelectedDocumentType, null, claimsResponse.Claims[claimIndex]));
-                claimIndex++;
+                result.DocumentSubmissions.Add(ds.ToResponse(documentType, ds.EvidenceRequestId, staffSelectedDocumentType, null, claim));
             }
 
             return result;
+        }
+
+        private Claim FindClaim(List<Claim> claims, DocumentSubmission documentSubmission)
+        {
+            return claims.Find(x => x.Id.ToString() == documentSubmission.ClaimId);
         }
 
         private DocumentType FindDocumentType(string teamName, string documentTypeId)

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -39,13 +39,8 @@ namespace EvidenceApi.V1.UseCase
 
             var result = new DocumentSubmissionResponseObject { Total = query.Total, DocumentSubmissions = new List<DocumentSubmissionResponse>() };
 
-            var claimsIds = new List<string>();
-            foreach (var ds in query.DocumentSubmissions)
-            {
-                claimsIds.Add(ds.ClaimId);
-            }
-
-            var claims = await _documentsApiGateway.GetClaimsByGroupId(groupId);
+            //do we need to paginate claims using the same method?? //returns pointers to the pagination state
+            var claimsResponse = await _documentsApiGateway.GetClaimsByGroupId(groupId);
 
             var claimIndex = 0;
             foreach (var ds in query.DocumentSubmissions)
@@ -53,7 +48,7 @@ namespace EvidenceApi.V1.UseCase
                 var documentType = FindDocumentType(ds.Team, ds.DocumentTypeId);
                 var staffSelectedDocumentType = FindStaffSelectedDocumentType(ds.Team,
                     ds.StaffSelectedDocumentTypeId);
-                result.DocumentSubmissions.Add(ds.ToResponse(documentType, ds.EvidenceRequestId, staffSelectedDocumentType, null, claims[claimIndex]));
+                result.DocumentSubmissions.Add(ds.ToResponse(documentType, ds.EvidenceRequestId, staffSelectedDocumentType, null, claimsResponse.Claims[claimIndex]));
                 claimIndex++;
             }
 

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -34,13 +34,15 @@ namespace EvidenceApi.V1.UseCase
 
             var groupId = _residentsGateway.GetGroupIdByResidentIdAndTeam(request);
 
-            //for pagination reasons, this method is still needed
             var query = _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request?.State, request?.PageSize, request?.Page);
 
             var result = new DocumentSubmissionResponseObject { Total = query.Total, DocumentSubmissions = new List<DocumentSubmissionResponse>() };
 
-            //do we need to paginate claims using the same method?? //returns pointers to the pagination state
-            var claimsResponse = await _documentsApiGateway.GetClaimsByGroupId(groupId);
+            //need to calculate pagination from query response
+
+            var claimsRequest = new PaginatedClaimRequest() { GroupId = groupId };
+
+            var claimsResponse = await _documentsApiGateway.GetClaimsByGroupId(claimsRequest);
 
             var claimIndex = 0;
             foreach (var ds in query.DocumentSubmissions)

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -17,24 +17,26 @@ namespace EvidenceApi.V1.UseCase
         private readonly IDocumentTypeGateway _documentTypeGateway;
         private readonly IStaffSelectedDocumentTypeGateway _staffSelectedDocumentTypeGateway;
         private readonly IDocumentsApiGateway _documentsApiGateway;
+        private readonly IResidentsGateway _residentsGateway;
 
-        public FindDocumentSubmissionsByResidentIdUseCase(IEvidenceGateway evidenceGateway, IDocumentTypeGateway documentTypeGateway, IStaffSelectedDocumentTypeGateway staffSelectedDocumentTypeGateway, IDocumentsApiGateway documentsApiGateway)
+        public FindDocumentSubmissionsByResidentIdUseCase(IEvidenceGateway evidenceGateway, IDocumentTypeGateway documentTypeGateway, IStaffSelectedDocumentTypeGateway staffSelectedDocumentTypeGateway, IDocumentsApiGateway documentsApiGateway, IResidentsGateway residentsGateway)
         {
             _evidenceGateway = evidenceGateway;
             _documentTypeGateway = documentTypeGateway;
             _staffSelectedDocumentTypeGateway = staffSelectedDocumentTypeGateway;
             _documentsApiGateway = documentsApiGateway;
+            _residentsGateway = residentsGateway;
         }
 
         public async Task<DocumentSubmissionResponseObject> ExecuteAsync(DocumentSubmissionSearchQuery request)
         {
             ValidateRequest(request);
 
-            //can remove this and replace with a call to the new table, to get the groupId by residentId && team - but how will this work for the pagination?
+            //get group Id
 
-            //var groupId = new Gateway? get groupId
-            var query =
-                _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request?.State, request?.PageSize, request?.Page);
+                //var groupId = _residentsGateway.GetGroupIdByResidentIdAndTeam(request);
+
+          var query = _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request?.State, request?.PageSize, request?.Page);
 
             //create result
             var result = new DocumentSubmissionResponseObject { Total = query.Total, DocumentSubmissions = new List<DocumentSubmissionResponse>() };

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -30,11 +30,16 @@ namespace EvidenceApi.V1.UseCase
         {
             ValidateRequest(request);
 
+            //can remove this and replace with a call to the new table, to get the groupId by residentId && team - but how will this work for the pagination?
+
+            //var groupId = new Gateway? get groupId
             var query =
                 _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request?.State, request?.PageSize, request?.Page);
 
+            //create result
             var result = new DocumentSubmissionResponseObject { Total = query.Total, DocumentSubmissions = new List<DocumentSubmissionResponse>() };
 
+            //we can use the groupId to do a query on the table to get all the claims
             var claimsIds = new List<string>();
             foreach (var ds in query.DocumentSubmissions)
             {
@@ -42,6 +47,7 @@ namespace EvidenceApi.V1.UseCase
             }
             var claims = await _documentsApiGateway.GetClaimsByIdsThrottled(claimsIds);
 
+            //build the object as before?
             var claimIndex = 0;
             foreach (var ds in query.DocumentSubmissions)
             {

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -39,7 +39,7 @@ namespace EvidenceApi.V1.UseCase
             if (groupId == null)
             {
                 //this should never happen - when the backfill is triggered, all residents will have an associated groupId
-               throw new BadRequestException($"Group Id is null for resident id {request.ResidentId}");
+                throw new BadRequestException($"Group Id is null for resident id {request.ResidentId}");
             }
 
             var query = _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request?.State, request?.PageSize, request?.Page);

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -32,17 +32,7 @@ namespace EvidenceApi.V1.UseCase
         {
             ValidateRequest(request);
 
-            Guid groupId;
-
-            //get groupId -- this is temporary error handling, to stop the e2e tests failing. groupId should never be empty
-            try
-            {
-                groupId = _residentsGateway.GetGroupIdByResidentIdAndTeam(request);
-            }
-            catch
-            {
-                groupId = Guid.Empty;
-            }
+            var groupId = _residentsGateway.GetGroupIdByResidentIdAndTeam(request);
 
             var query = _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request?.State, request?.PageSize, request?.Page);
 

--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -34,9 +34,9 @@ namespace EvidenceApi.V1.UseCase
 
             var groupId = _residentsGateway.GetGroupIdByResidentIdAndTeam(request);
 
+            //for pagination reasons, this method is still needed
             var query = _evidenceGateway.GetPaginatedDocumentSubmissionsByResidentId(request.ResidentId, request?.State, request?.PageSize, request?.Page);
 
-            // we still need this query
             var result = new DocumentSubmissionResponseObject { Total = query.Total, DocumentSubmissions = new List<DocumentSubmissionResponse>() };
 
             var claimsIds = new List<string>();
@@ -45,19 +45,8 @@ namespace EvidenceApi.V1.UseCase
                 claimsIds.Add(ds.ClaimId);
             }
 
-            List<Claim> claims;
+            var claims = await _documentsApiGateway.GetClaimsByGroupId(groupId);
 
-            if (groupId == Guid.Empty)
-            {
-                claims = await _documentsApiGateway.GetClaimsByIdsThrottled(claimsIds);
-            }
-            else
-            {
-                //this is where the performance improvement will come from. Get all the claims at once, rather than dozens of API calls
-                claims = await _documentsApiGateway.GetClaimsByGroupId(groupId);
-            }
-
-            //build the object as before?
             var claimIndex = 0;
             foreach (var ds in query.DocumentSubmissions)
             {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/c/projects/DOC/boards/68?modal=detail&selectedIssue=DOC-1399

## Describe this PR

### *What is the problem we're trying to solve*

This PR refactors the method fetching document submissions and their associated claims. By introducing the group_id column, we are more easily able to link documents and claims. Therefore, instead of multiple calls to the Documents_API to fetch claims, we only need a single call. This should provide tangible performance benefits for the application.

### *What changes have we introduced*

- Added new gateway method to get claims by groupId
- Added new gateway method to get groupId by residentId & team
- Updated FindDocSubmissionsByResidentId use case to use the two new gateway methods, avoiding unneeded API calls.
- Added and updated tests for the new and refactored methods, as well as E2E tests.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

This has a dependency on DOC-1402, so cannot be merged until that is ready. It may create merge conflicts as I believe some of the same files are being edited.
