### PR TITLE
Add groupId to all upload flows

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/BaseControllerTests.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/BaseControllerTests.cs
@@ -57,7 +57,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
                 ""resident"": {
                     ""name"": ""Test"",
                     ""email"": ""test@test.com,"",
-                    ""phoneNumber"": ""+447123456789""
+                    ""phoneNumber"": ""+447123456789"",
+                    ""team"": ""null""
                 },
                 ""deliveryMethods"": [""SMS""],
                 ""documentTypes"": [""proof-of-id""],

--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -215,12 +215,15 @@ namespace EvidenceApi.Tests.V1.E2ETests
         public async Task CreateDocumentSubmissionUnsuccessfulWhenCannotCreateClaim()
         {
             // Arrange
+            var resident = _fixture.Create<Resident>();
             var entity = _fixture.Build<EvidenceRequest>()
                 .With(x => x.DocumentTypes, new List<string> { "passport-scan" })
                 .With(x => x.DeliveryMethods, new List<DeliveryMethod> { DeliveryMethod.Email })
                 .Without(x => x.Communications)
                 .Without(x => x.DocumentSubmissions)
                 .Create();
+            entity.ResidentId = resident.Id;
+            DatabaseContext.Residents.Add(resident);
             DatabaseContext.EvidenceRequests.Add(entity);
             DatabaseContext.SaveChanges();
 
@@ -317,13 +320,16 @@ namespace EvidenceApi.Tests.V1.E2ETests
         public async Task CreateDocumentSubmissionUnsuccessfulWhenCannotCreateUploadPolicy()
         {
             // Arrange
+            var resident = _fixture.Create<Resident>();
             var entity = _fixture.Build<EvidenceRequest>()
                 .With(x => x.DocumentTypes, new List<string> { "passport-scan" })
                 .With(x => x.DeliveryMethods, new List<DeliveryMethod> { DeliveryMethod.Email })
                 .Without(x => x.Communications)
                 .Without(x => x.DocumentSubmissions)
                 .Create();
+            entity.ResidentId = resident.Id;
             DatabaseContext.EvidenceRequests.Add(entity);
+            DatabaseContext.Residents.Add(resident);
             DatabaseContext.SaveChanges();
 
             DocumentsApiServer.Reset();

--- a/EvidenceApi.Tests/V1/E2ETests/ResidentsTests.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/ResidentsTests.cs
@@ -67,7 +67,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             string body = "{" +
                           "\"name\": \"Test Resident\"," +
                           "\"email\": \"resident@email\"," +
-                          "\"phoneNumber\": \"0700000\"" +
+                          "\"phoneNumber\": \"0700000\"," +
+                          "\"team\": \"some team\"" +
                           "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
@@ -82,7 +83,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             string body = "{" +
                           "\"name\": \"Test Resident\"," +
                           "\"email\": \"\"," +
-                          "\"phoneNumber\": \"\"" +
+                          "\"phoneNumber\": \"\"," +
+                          "\"team\": \"some team\"" +
                           "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
@@ -98,7 +100,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             string body = "{" +
                           "\"name\": \"\"," +
                           "\"email\": \"resident@email\"," +
-                          "\"phoneNumber\": \"0700000\"" +
+                          "\"phoneNumber\": \"0700000\"," +
+                          "\"team\": \"some team\"" +
                           "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");
@@ -122,7 +125,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
             string body = "{" +
                           "\"name\": \"Test Resident\"," +
                           "\"email\": \"resident@email\"," +
-                          "\"phoneNumber\": \"0700000\"" +
+                          "\"phoneNumber\": \"0700000\"," +
+                          "\"team\": \"some team\"" +
                           "}";
 
             var jsonString = new StringContent(body, Encoding.UTF8, "application/json");

--- a/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using AutoFixture;
 using EvidenceApi.V1.Domain;
@@ -281,13 +282,17 @@ namespace EvidenceApi.Tests.V1.Gateways
         [Test]
         public void AddResidentGroupIdAddsNewEntry()
         {
-            var request = _fixture.Create<Resident>();
+            var residentId = Guid.NewGuid();
+            var team = "some team";
+            // Add resident for FK constraint
+            var resident = _fixture.Create<Resident>();
+            resident.Id = residentId;
+            DatabaseContext.Residents.Add(resident);
+            DatabaseContext.SaveChanges();
 
-            var expectedId = request.Id;
+            _classUnderTest.AddResidentGroupId(residentId, team);
 
-            _classUnderTest.AddResidentGroupId(request);
-
-            var query = DatabaseContext.ResidentsTeamGroupId.Where(x => x.ResidentId == expectedId);
+            var query = DatabaseContext.ResidentsTeamGroupId.Where(x => x.ResidentId == residentId && x.Team == team);
 
             query.Count()
                 .Should()
@@ -295,8 +300,54 @@ namespace EvidenceApi.Tests.V1.Gateways
 
             var foundRecord = query.First();
             foundRecord.Id.Should().NotBeEmpty();
-            foundRecord.Resident.Should().Be(request);
+            foundRecord.Resident.Id.Should().Be(residentId);
+            foundRecord.Team.Should().Be(team);
+        }
 
+        [Test]
+        public void FindsGroupIdByResidentIdAndTeamWhenGroupIdExists()
+        {
+            var residentId = Guid.NewGuid();
+            var resident = _fixture.Create<Resident>();
+            resident.Id = residentId;
+            var team = "some team";
+            var groupId = Guid.NewGuid();
+            DatabaseContext.Residents.Add(resident);
+
+            var residentTeamGroupId = _fixture.Create<ResidentsTeamGroupId>();
+            residentTeamGroupId.ResidentId = residentId;
+            residentTeamGroupId.Team = team;
+            residentTeamGroupId.GroupId = groupId;
+            residentTeamGroupId.Resident = resident;
+
+            DatabaseContext.ResidentsTeamGroupId.Add(residentTeamGroupId);
+            DatabaseContext.SaveChanges();
+
+            var result = _classUnderTest.FindGroupIdByResidentIdAndTeam(residentId, team);
+            result.Should().Be(groupId);
+        }
+
+        [Test]
+        public void FindGroupIdByResidentIdAndTeamReturnsNullWhenNoRecordFound()
+        {
+            var residentId = Guid.NewGuid();
+            var resident = _fixture.Create<Resident>();
+            resident.Id = residentId;
+            var team = "some team";
+            DatabaseContext.Residents.Add(resident);
+
+            var residentTeamGroupId = _fixture.Build<ResidentsTeamGroupId>()
+                .Without(x => x.GroupId)
+                .Create();
+            residentTeamGroupId.ResidentId = residentId;
+            residentTeamGroupId.Team = team;
+            residentTeamGroupId.Resident = resident;
+
+            DatabaseContext.ResidentsTeamGroupId.Add(residentTeamGroupId);
+            DatabaseContext.SaveChanges();
+
+            var result = _classUnderTest.FindGroupIdByResidentIdAndTeam(residentId, team);
+            result.Should().BeNull();
         }
     }
 }

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests.cs
@@ -19,6 +19,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         private Mock<IEvidenceGateway> _evidenceGateway = new Mock<IEvidenceGateway>();
         private Mock<IDocumentsApiGateway> _documentsApiGateway = new Mock<IDocumentsApiGateway>();
         private Mock<IStaffSelectedDocumentTypeGateway> _staffSelectedDocumentTypeGateway = new Mock<IStaffSelectedDocumentTypeGateway>();
+        private Mock<IResidentsGateway> _residentsGateway = new Mock<IResidentsGateway>();
         private readonly IFixture _fixture = new Fixture();
         private DocumentType _staffSelectedDocumentType;
         private DocumentSubmission _created;
@@ -27,7 +28,7 @@ namespace EvidenceApi.Tests.V1.UseCase
         [SetUp]
         public void SetUp()
         {
-            _classUnderTest = new CreateDocumentSubmissionWithoutEvidenceRequestUseCase(_evidenceGateway.Object, _documentsApiGateway.Object, _staffSelectedDocumentTypeGateway.Object);
+            _classUnderTest = new CreateDocumentSubmissionWithoutEvidenceRequestUseCase(_evidenceGateway.Object, _documentsApiGateway.Object, _staffSelectedDocumentTypeGateway.Object, _residentsGateway.Object);
         }
 
         [Test]
@@ -149,6 +150,50 @@ namespace EvidenceApi.Tests.V1.UseCase
             result.UploadPolicy.Should().BeEquivalentTo(s3UploadPolicy);
             result.Team.Should().BeEquivalentTo(_created.Team);
             result.ResidentId.Should().Be(_created.ResidentId);
+        }
+
+        [Test]
+        public async Task AddsGroupIdToResidentsTeamGroupIdWhenNotNull()
+        {
+            _staffSelectedDocumentType = _fixture.Create<DocumentType>();
+            _created = DocumentSubmissionFixture();
+            _request = CreateRequestFixture();
+
+            var claim = _fixture.Create<Claim>();
+            var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
+
+            SetupDocumentsApiGateway(_request, claim, s3UploadPolicy);
+            var staffSelectedDocumentType = SetupStaffSelectedDocumentTypeGateway(_request.StaffSelectedDocumentTypeId);
+            SetupEvidenceGateway();
+            _residentsGateway
+                .Setup(x =>
+                    x.FindGroupIdByResidentIdAndTeam(It.IsAny<Guid>(), It.IsAny<string>())
+                ).Returns(Guid.NewGuid());
+
+            var result = await _classUnderTest.ExecuteAsync(_request).ConfigureAwait(true);
+            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public async Task AddsGroupIdToResidentsTeamGroupIdWhenNull()
+        {
+            _staffSelectedDocumentType = _fixture.Create<DocumentType>();
+            _created = DocumentSubmissionFixture();
+            _request = CreateRequestFixture();
+
+            var claim = _fixture.Create<Claim>();
+            var s3UploadPolicy = _fixture.Create<S3UploadPolicy>();
+
+            SetupDocumentsApiGateway(_request, claim, s3UploadPolicy);
+            var staffSelectedDocumentType = SetupStaffSelectedDocumentTypeGateway(_request.StaffSelectedDocumentTypeId);
+            SetupEvidenceGateway();
+            _residentsGateway
+                .Setup(x =>
+                    x.FindGroupIdByResidentIdAndTeam(It.IsAny<Guid>(), It.IsAny<string>())
+                ).Returns(() => null);
+
+            var result = await _classUnderTest.ExecuteAsync(_request).ConfigureAwait(true);
+            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>()), Times.Once);
         }
 
         private DocumentSubmissionWithoutEvidenceRequestRequest CreateRequestFixture()

--- a/EvidenceApi.Tests/V1/UseCase/CreateEvidenceRequestUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateEvidenceRequestUseCaseTests.cs
@@ -124,6 +124,7 @@ namespace EvidenceApi.Tests.V1.UseCase
 
         private void SetupMocks()
         {
+            var team = "some team";
             _resident = _fixture.Create<Resident>();
             _documentType = _fixture.Create<DocumentType>();
             _created = TestDataHelper.EvidenceRequest();
@@ -133,7 +134,8 @@ namespace EvidenceApi.Tests.V1.UseCase
             {
                 Email = _resident.Email,
                 Name = _resident.Name,
-                PhoneNumber = _resident.PhoneNumber
+                PhoneNumber = _resident.PhoneNumber,
+                Team = team
             };
             var noteToResident = "This is a note to resident";
 

--- a/EvidenceApi.Tests/V1/UseCase/CreateResidentUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateResidentUseCaseTests.cs
@@ -48,7 +48,8 @@ namespace EvidenceApi.Tests.V1.UseCase
             {
                 Name = "Test",
                 Email = "",
-                PhoneNumber = ""
+                PhoneNumber = "",
+                Team = "some team"
             };
 
             Func<ResidentResponse> testDelegate = () => _classUnderTest.Execute(request);
@@ -62,7 +63,8 @@ namespace EvidenceApi.Tests.V1.UseCase
             {
                 Name = "",
                 Email = "resident@email",
-                PhoneNumber = "070000"
+                PhoneNumber = "070000",
+                Team = "some team"
             };
 
             Func<ResidentResponse> testDelegate = () => _classUnderTest.Execute(request);
@@ -80,14 +82,28 @@ namespace EvidenceApi.Tests.V1.UseCase
             testDelegate.Should().Throw<BadRequestException>().WithMessage("A resident with these details already exists.");
         }
 
+        [Test]
+        public void ThrowsBadRequestWhenTeamIsNullOrEmpty()
+        {
+            SetupMocks();
+            _residentRequest.Team = "";
+            _residentsGateway.Setup(x => x.FindResident(It.IsAny<Resident>())).Returns(_resident).Verifiable();
+
+            Func<ResidentResponse> testDelegate = () => _classUnderTest.Execute(_residentRequest);
+
+            testDelegate.Should().Throw<BadRequestException>().WithMessage("'Team' cannot be null or empty.");
+        }
+
         private void SetupMocks()
         {
             _resident = TestDataHelper.Resident();
+            var team = "some team";
             _residentRequest = new ResidentRequest
             {
                 Email = _resident.Email,
                 Name = _resident.Name,
-                PhoneNumber = _resident.PhoneNumber
+                PhoneNumber = _resident.PhoneNumber,
+                Team = team
             };
             _residentsGateway.Setup(x => x.CreateResident(It.IsAny<Resident>())).Returns(_resident).Verifiable();
         }

--- a/EvidenceApi.Tests/V1/UseCase/EvidenceRequestValidatorTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/EvidenceRequestValidatorTests.cs
@@ -189,7 +189,8 @@ namespace EvidenceApi.Tests.V1.UseCase
                 {
                     Name = "Tom",
                     Email = "tom@hackney.gov.uk",
-                    PhoneNumber = "+447123456789"
+                    PhoneNumber = "+447123456789",
+                    Team = "some team"
                 },
                 DocumentTypes = new List<string> { "passport-scan" }
             };

--- a/EvidenceApi.Tests/V1/UseCase/ResidentRequestValidatorTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/ResidentRequestValidatorTests.cs
@@ -57,7 +57,8 @@ namespace EvidenceApi.Tests.V1.UseCase
             {
                 Name = "Tom",
                 Email = "tom@hackney.gov.uk",
-                PhoneNumber = "+447123456789"
+                PhoneNumber = "+447123456789",
+                Team = "some team"
             };
         }
     }

--- a/EvidenceApi/V1/Boundary/Request/ClaimRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/ClaimRequest.cs
@@ -10,5 +10,6 @@ namespace EvidenceApi.V1.Boundary.Request
         public string DocumentDescription { get; set; }
         public DateTime RetentionExpiresAt { get; set; }
         public DateTime ValidUntil { get; set; }
+        public Guid GroupId { get; set; }
     }
 }

--- a/EvidenceApi/V1/Boundary/Request/ResidentRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/ResidentRequest.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using EvidenceApi.V1.Domain;
-
 namespace EvidenceApi.V1.Boundary.Request
 {
     public class ResidentRequest
@@ -8,5 +5,6 @@ namespace EvidenceApi.V1.Boundary.Request
         public string Name { get; set; }
         public string Email { get; set; }
         public string PhoneNumber { get; set; }
+        public string Team { get; set; }
     }
 }

--- a/EvidenceApi/V1/Gateways/Interfaces/IResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IResidentsGateway.cs
@@ -11,6 +11,7 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         Resident FindResident(Resident request);
         List<Resident> FindResidents(string searchQuery);
         Resident CreateResident(Resident request);
-        void AddResidentGroupId(Resident request);
+        Guid AddResidentGroupId(Guid residentId, string team);
+        Guid? FindGroupIdByResidentIdAndTeam(Guid residentId, string team);
     }
 }

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -81,8 +81,8 @@ namespace EvidenceApi.V1.Gateways
         public Guid? FindGroupIdByResidentIdAndTeam(Guid residentId, string team)
         {
             var entity = _databaseContext.ResidentsTeamGroupId
-                .FirstOrDefault(residentTeamGroupId => 
-                    residentTeamGroupId.ResidentId == residentId && 
+                .FirstOrDefault(residentTeamGroupId =>
+                    residentTeamGroupId.ResidentId == residentId &&
                     residentTeamGroupId.Team == team);
             if (entity == null)
             {

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -68,14 +68,27 @@ namespace EvidenceApi.V1.Gateways
             return request;
         }
 
-        public void AddResidentGroupId(Resident request)
+        public Guid AddResidentGroupId(Guid residentId, string team)
         {
             var groupId = Guid.NewGuid();
-            var newEntry = new ResidentsTeamGroupId() { Resident = request, GroupId = groupId };
+            var newEntry = new ResidentsTeamGroupId() { ResidentId = residentId, GroupId = groupId, Team = team };
 
             _databaseContext.ResidentsTeamGroupId.Add(newEntry);
             _databaseContext.SaveChanges();
+            return groupId;
+        }
 
+        public Guid? FindGroupIdByResidentIdAndTeam(Guid residentId, string team)
+        {
+            var entity = _databaseContext.ResidentsTeamGroupId
+                .FirstOrDefault(residentTeamGroupId => 
+                    residentTeamGroupId.ResidentId == residentId && 
+                    residentTeamGroupId.Team == team);
+            if (entity == null)
+            {
+                return null;
+            }
+            return entity.GroupId;
         }
     }
 }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -62,7 +62,7 @@ namespace EvidenceApi.V1.UseCase
             }
             try
             {
-                var claimRequest = BuildClaimRequest(evidenceRequest, (Guid)groupId);
+                var claimRequest = BuildClaimRequest(evidenceRequest, (Guid) groupId);
                 claim = await _documentsApiGateway.CreateClaim(claimRequest);
                 createdS3UploadPolicy = await _documentsApiGateway.CreateUploadPolicy(claim.Document.Id);
             }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -16,17 +16,20 @@ namespace EvidenceApi.V1.UseCase
         private readonly IEvidenceGateway _evidenceGateway;
         private readonly IDocumentsApiGateway _documentsApiGateway;
         private readonly IDocumentTypeGateway _documentTypeGateway;
+        private readonly IResidentsGateway _residentsGateway;
         private readonly IUpdateEvidenceRequestStateUseCase _updateEvidenceRequestStateUseCase;
 
         public CreateDocumentSubmissionUseCase(
             IEvidenceGateway evidenceGateway,
             IDocumentsApiGateway documentsApiGateway,
             IDocumentTypeGateway documentTypeGateway,
+            IResidentsGateway residentsGateway,
             IUpdateEvidenceRequestStateUseCase updateEvidenceRequestStateUseCase)
         {
             _evidenceGateway = evidenceGateway;
             _documentsApiGateway = documentsApiGateway;
             _documentTypeGateway = documentTypeGateway;
+            _residentsGateway = residentsGateway;
             _updateEvidenceRequestStateUseCase = updateEvidenceRequestStateUseCase;
         }
 
@@ -52,9 +55,14 @@ namespace EvidenceApi.V1.UseCase
             Claim claim;
             S3UploadPolicy createdS3UploadPolicy;
 
+            var groupId = _residentsGateway.FindGroupIdByResidentIdAndTeam(evidenceRequest.ResidentId, evidenceRequest.Team);
+            if (groupId == null)
+            {
+                groupId = _residentsGateway.AddResidentGroupId(evidenceRequest.ResidentId, evidenceRequest.Team);
+            }
             try
             {
-                var claimRequest = BuildClaimRequest(evidenceRequest);
+                var claimRequest = BuildClaimRequest(evidenceRequest, (Guid)groupId);
                 claim = await _documentsApiGateway.CreateClaim(claimRequest);
                 createdS3UploadPolicy = await _documentsApiGateway.CreateUploadPolicy(claim.Document.Id);
             }
@@ -75,7 +83,7 @@ namespace EvidenceApi.V1.UseCase
             return createdDocumentSubmission.ToResponse(documentType, documentSubmission.EvidenceRequestId, null, createdS3UploadPolicy, claim);
         }
 
-        private static ClaimRequest BuildClaimRequest(EvidenceRequest evidenceRequest)
+        private static ClaimRequest BuildClaimRequest(EvidenceRequest evidenceRequest, Guid groupId)
         {
             var claimRequest = new ClaimRequest()
             {
@@ -83,7 +91,8 @@ namespace EvidenceApi.V1.UseCase
                 UserCreatedBy = evidenceRequest.UserRequestedBy,
                 ApiCreatedBy = "evidence_api",
                 RetentionExpiresAt = DateTime.UtcNow.AddMonths(3).Date,
-                ValidUntil = DateTime.UtcNow.AddMonths(3).Date
+                ValidUntil = DateTime.UtcNow.AddMonths(3).Date,
+                GroupId = groupId
             };
             return claimRequest;
         }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
@@ -18,15 +18,18 @@ namespace EvidenceApi.V1.UseCase
         private readonly IEvidenceGateway _evidenceGateway;
         private readonly IDocumentsApiGateway _documentsApiGateway;
         private readonly IStaffSelectedDocumentTypeGateway _staffSelectedDocumentTypeGateway;
+        private readonly IResidentsGateway _residentsGateway;
 
         public CreateDocumentSubmissionWithoutEvidenceRequestUseCase(
             IEvidenceGateway evidenceGateway,
             IDocumentsApiGateway documentsApiGateway,
-            IStaffSelectedDocumentTypeGateway staffSelectedDocumentTypeGateway)
+            IStaffSelectedDocumentTypeGateway staffSelectedDocumentTypeGateway,
+            IResidentsGateway residentsGateway)
         {
             _evidenceGateway = evidenceGateway;
             _documentsApiGateway = documentsApiGateway;
             _staffSelectedDocumentTypeGateway = staffSelectedDocumentTypeGateway;
+            _residentsGateway = residentsGateway;
         }
 
         public async Task<DocumentSubmissionWithoutEvidenceRequestResponse> ExecuteAsync(DocumentSubmissionWithoutEvidenceRequestRequest request)
@@ -40,9 +43,21 @@ namespace EvidenceApi.V1.UseCase
             Claim claim;
             S3UploadPolicy createdS3UploadPolicy;
 
+            var groupId = _residentsGateway.FindGroupIdByResidentIdAndTeam(request.ResidentId, request.Team);
+            if (groupId == null)
+            {
+                try
+                {
+                    groupId = _residentsGateway.AddResidentGroupId(request.ResidentId, request.Team);
+                }
+                catch (Exception)
+                {
+                    throw new BadRequestException($"A resident with ID {request.ResidentId} does not exist.");
+                }
+            }
             try
             {
-                var claimRequest = BuildClaimRequest(request);
+                var claimRequest = BuildClaimRequest(request, (Guid)groupId);
                 claim = await _documentsApiGateway.CreateClaim(claimRequest);
                 createdS3UploadPolicy = await _documentsApiGateway.CreateUploadPolicy(claim.Document.Id);
             }
@@ -67,7 +82,7 @@ namespace EvidenceApi.V1.UseCase
             return createdDocumentSubmission.ToResponse(staffSelectedDocumentType, createdS3UploadPolicy, claim);
         }
 
-        private static ClaimRequest BuildClaimRequest(DocumentSubmissionWithoutEvidenceRequestRequest request)
+        private static ClaimRequest BuildClaimRequest(DocumentSubmissionWithoutEvidenceRequestRequest request, Guid groupId)
         {
             var claimRequest = new ClaimRequest()
             {
@@ -76,7 +91,8 @@ namespace EvidenceApi.V1.UseCase
                 ApiCreatedBy = "evidence_api",
                 RetentionExpiresAt = DateTime.UtcNow.AddMonths(3).Date,
                 ValidUntil = DateTime.UtcNow.AddMonths(3).Date,
-                DocumentDescription = request.DocumentDescription
+                DocumentDescription = request.DocumentDescription,
+                GroupId = groupId
             };
             return claimRequest;
         }

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
@@ -57,7 +57,7 @@ namespace EvidenceApi.V1.UseCase
             }
             try
             {
-                var claimRequest = BuildClaimRequest(request, (Guid)groupId);
+                var claimRequest = BuildClaimRequest(request, (Guid) groupId);
                 claim = await _documentsApiGateway.CreateClaim(claimRequest);
                 createdS3UploadPolicy = await _documentsApiGateway.CreateUploadPolicy(claim.Document.Id);
             }

--- a/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
@@ -52,6 +52,7 @@ namespace EvidenceApi.V1.UseCase
             }
 
             var resident = _residentsGateway.FindOrCreateResident(BuildResident(request.Resident));
+            _residentsGateway.AddResidentGroupId(resident.Id, request.Team);
             var documentTypes = request.DocumentTypes.ConvertAll<DocumentType>(dt => _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(request.Team, dt));
 
             var residentReferenceId = _findOrCreateResidentReferenceIdUseCase.Execute(resident);

--- a/EvidenceApi/V1/UseCase/CreateResidentUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateResidentUseCase.cs
@@ -7,6 +7,7 @@ using EvidenceApi.V1.Factories;
 using EvidenceApi.V1.Boundary.Response.Exceptions;
 using Microsoft.Extensions.Logging;
 using System.Linq;
+using System;
 
 namespace EvidenceApi.V1.UseCase
 {
@@ -29,6 +30,11 @@ namespace EvidenceApi.V1.UseCase
                 throw new BadRequestException(validation.Errors.First().ToString());
             }
 
+            if (String.IsNullOrEmpty(request.Team))
+            {
+                throw new BadRequestException("'Team' cannot be null or empty.");
+            }
+
             var resident = new Resident()
             {
                 Email = request.Email,
@@ -43,7 +49,7 @@ namespace EvidenceApi.V1.UseCase
             }
             var createdResident = _residentsGateway.CreateResident(resident);
 
-            _residentsGateway.AddResidentGroupId(createdResident);
+            _residentsGateway.AddResidentGroupId(createdResident.Id, request.Team);
 
             return createdResident.ToResponse();
         }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1402

## Describe this PR

### *What changes have we introduced*

Updated all use cases that are creating document submissions to check for the existence of a `groupId` for a resident for a team in `residents_team_group_id` table and if no record is found a new entry is added with a fresh `groupId`.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
