### PR TITLE
Error handling for Null GroupId

### DIFF
--- a/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
+++ b/EvidenceApi/V1/UseCase/FindDocumentSubmissionsByResidentIdUseCase.cs
@@ -40,6 +40,12 @@ namespace EvidenceApi.V1.UseCase
 
             var result = new DocumentSubmissionResponseObject { Total = query.Total, DocumentSubmissions = new List<DocumentSubmissionResponse>() };
 
+            if (groupId == null || groupId == Guid.Empty)
+            {
+                Console.WriteLine($"No group id found for resident {request.ResidentId}");
+                return result;
+            }
+
             var claimsRequest = new PaginatedClaimRequest() { GroupId = groupId };
 
             var claimsResponse = await _documentsApiGateway.GetClaimsByGroupId(claimsRequest);


### PR DESCRIPTION
This will ensure that if there is no associated groupId for the resident (for example the resident has been created by a different team), it returns no documents rather than throwing an unhandled exception.