### PR TITLE
DOC-1413: Handle possible null value to avoid 500 error

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/ResidentsTests.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/ResidentsTests.cs
@@ -79,7 +79,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             DatabaseContext.SaveChanges();
 
             // Act
-            var uri = new Uri($"api/v1/residents/search/?&groupId={residentGroupId.GroupId}", UriKind.Relative);
+            var uri = new Uri($"api/v1/residents/search/?groupId={residentGroupId.GroupId}", UriKind.Relative);
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
 
             // Assert
@@ -139,7 +139,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             DatabaseContext.SaveChanges();
 
             // Act
-            var uri = new Uri($"api/v1/residents/search/?&groupId={anotherGuid}", UriKind.Relative);
+            var uri = new Uri($"api/v1/residents/search/?groupId={anotherGuid}", UriKind.Relative);
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
 
             // Assert

--- a/EvidenceApi.Tests/V1/E2ETests/ResidentsTests.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/ResidentsTests.cs
@@ -79,7 +79,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             DatabaseContext.SaveChanges();
 
             // Act
-            var uri = new Uri($"api/v1/residents/search/?&searchQuery=name=&groupId={residentGroupId.GroupId}", UriKind.Relative);
+            var uri = new Uri($"api/v1/residents/search/?&groupId={residentGroupId.GroupId}", UriKind.Relative);
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
 
             // Assert
@@ -139,7 +139,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
             DatabaseContext.SaveChanges();
 
             // Act
-            var uri = new Uri($"api/v1/residents/search/?&searchQuery=name=&groupId={anotherGuid}", UriKind.Relative);
+            var uri = new Uri($"api/v1/residents/search/?&groupId={anotherGuid}", UriKind.Relative);
             var response = await Client.GetAsync(uri).ConfigureAwait(true);
 
             // Assert

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -44,7 +44,7 @@ namespace EvidenceApi.V1.Gateways
              * If we notice it is performing poorly then we could instead use raw SQL queries with named parameters.
              * See - https://docs.microsoft.com/en-us/ef/core/querying/raw-sql
              */
-            var searchQueryLowerCase = searchQuery.ToLower();
+            var searchQueryLowerCase = searchQuery?.ToLower();
             return _databaseContext.Residents
                 .Where(r =>
                     r.Name.ToLower().StartsWith(searchQueryLowerCase) ||


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1413

## Describe this PR

### *What is the problem we're trying to solve*

We don't want to get a 500 when calling this endpoint with no `searchQuery` parameter, ie when using the `groupId` parameter.

### *What changes have we introduced*

Added null check operator for the parameter in the gateway.
Corrected URLs for e2e tests, as now the endpoint can effectively be called with the `groupId` parameter only.