### PR TITLE
DOC-1394 - Generate GroupId Guid If Not Provided In Create Resident Request

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/BaseControllerTests.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/BaseControllerTests.cs
@@ -58,7 +58,8 @@ namespace EvidenceApi.Tests.V1.E2ETests
                     ""name"": ""Test"",
                     ""email"": ""test@test.com,"",
                     ""phoneNumber"": ""+447123456789"",
-                    ""team"": ""null""
+                    ""team"": ""null"",
+                    ""groupId"": ""null""
                 },
                 ""deliveryMethods"": [""SMS""],
                 ""documentTypes"": [""proof-of-id""],

--- a/EvidenceApi.Tests/V1/E2ETests/BaseControllerTests.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/BaseControllerTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;

--- a/EvidenceApi.Tests/V1/E2ETests/BaseControllerTests.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/BaseControllerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
@@ -59,7 +60,7 @@ namespace EvidenceApi.Tests.V1.E2ETests
                     ""email"": ""test@test.com,"",
                     ""phoneNumber"": ""+447123456789"",
                     ""team"": ""null"",
-                    ""groupId"": ""null""
+                    ""groupId"": null
                 },
                 ""deliveryMethods"": [""SMS""],
                 ""documentTypes"": [""proof-of-id""],

--- a/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/ResidentsGatewayTests.cs
@@ -333,7 +333,7 @@ namespace EvidenceApi.Tests.V1.Gateways
             DatabaseContext.Residents.Add(resident);
             DatabaseContext.SaveChanges();
 
-            _classUnderTest.AddResidentGroupId(residentId, team);
+            _classUnderTest.AddResidentGroupId(residentId, team, null);
 
             var query = DatabaseContext.ResidentsTeamGroupId.Where(x => x.ResidentId == residentId && x.Team == team);
 
@@ -345,6 +345,33 @@ namespace EvidenceApi.Tests.V1.Gateways
             foundRecord.Id.Should().NotBeEmpty();
             foundRecord.Resident.Id.Should().Be(residentId);
             foundRecord.Team.Should().Be(team);
+        }
+
+        [Test]
+        public void AddResidentGroupIdAddsNewEntryWithGroupIdProvided()
+        {
+            var residentId = Guid.NewGuid();
+            var providedGroupId = Guid.NewGuid();
+            var team = "some team";
+            // Add resident for FK constraint
+            var resident = _fixture.Create<Resident>();
+            resident.Id = residentId;
+            DatabaseContext.Residents.Add(resident);
+            DatabaseContext.SaveChanges();
+
+            _classUnderTest.AddResidentGroupId(residentId, team, providedGroupId);
+
+            var query = DatabaseContext.ResidentsTeamGroupId.Where(x => x.ResidentId == residentId && x.Team == team);
+
+            query.Count()
+                .Should()
+                .Be(1);
+
+            var foundRecord = query.First();
+            foundRecord.Id.Should().NotBeEmpty();
+            foundRecord.Resident.Id.Should().Be(residentId);
+            foundRecord.Team.Should().Be(team);
+            foundRecord.GroupId.Should().Be(providedGroupId);
         }
 
         [Test]

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionUseCaseTests.cs
@@ -230,7 +230,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             var docType = SetupDocumentTypeGateway(_request.DocumentType);
 
             var result = await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request).ConfigureAwait(true);
-            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>(), null), Times.Never);
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace EvidenceApi.Tests.V1.UseCase
             var docType = SetupDocumentTypeGateway(_request.DocumentType);
 
             var result = await _classUnderTest.ExecuteAsync(evidenceRequest.Id, _request).ConfigureAwait(true);
-            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>()), Times.Once);
+            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>(), null), Times.Once);
         }
 
         private DocumentSubmissionRequest CreateRequestFixture()

--- a/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests.cs
+++ b/EvidenceApi.Tests/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCaseTests.cs
@@ -171,7 +171,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 ).Returns(Guid.NewGuid());
 
             var result = await _classUnderTest.ExecuteAsync(_request).ConfigureAwait(true);
-            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>(), null), Times.Never);
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace EvidenceApi.Tests.V1.UseCase
                 ).Returns(() => Guid.Empty);
 
             var result = await _classUnderTest.ExecuteAsync(_request).ConfigureAwait(true);
-            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>()), Times.Once);
+            _residentsGateway.Verify(x => x.AddResidentGroupId(It.IsAny<Guid>(), It.IsAny<string>(), null), Times.Once);
         }
 
         private DocumentSubmissionWithoutEvidenceRequestRequest CreateRequestFixture()

--- a/EvidenceApi/V1/Boundary/Request/ResidentRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/ResidentRequest.cs
@@ -8,6 +8,6 @@ namespace EvidenceApi.V1.Boundary.Request
         public string Email { get; set; }
         public string PhoneNumber { get; set; }
         public string Team { get; set; }
-        public Guid? GroupId => null;
+        public Guid? GroupId { get; set; }
     }
 }

--- a/EvidenceApi/V1/Boundary/Request/ResidentRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/ResidentRequest.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace EvidenceApi.V1.Boundary.Request
 {
     public class ResidentRequest
@@ -6,5 +8,6 @@ namespace EvidenceApi.V1.Boundary.Request
         public string Email { get; set; }
         public string PhoneNumber { get; set; }
         public string Team { get; set; }
+        public Guid? GroupId { get; set; }
     }
 }

--- a/EvidenceApi/V1/Boundary/Request/ResidentRequest.cs
+++ b/EvidenceApi/V1/Boundary/Request/ResidentRequest.cs
@@ -8,6 +8,6 @@ namespace EvidenceApi.V1.Boundary.Request
         public string Email { get; set; }
         public string PhoneNumber { get; set; }
         public string Team { get; set; }
-        public Guid? GroupId { get; set; }
+        public Guid? GroupId => null;
     }
 }

--- a/EvidenceApi/V1/Controllers/ResidentsController.cs
+++ b/EvidenceApi/V1/Controllers/ResidentsController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using EvidenceApi.V1.Boundary.Request;
 using EvidenceApi.V1.Boundary.Response.Exceptions;
 using EvidenceApi.V1.UseCase.Interfaces;

--- a/EvidenceApi/V1/Gateways/Interfaces/IResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/Interfaces/IResidentsGateway.cs
@@ -15,7 +15,7 @@ namespace EvidenceApi.V1.Gateways.Interfaces
         List<Resident> FindResidents(string searchQuery);
         Resident CreateResident(Resident request);
         List<GroupResidentIdClaimIdBackfillObject> GetAllResidentIdsAndGroupIdsByFirstCharacter(string groupIdFirstTwoCharacters);
-        Guid AddResidentGroupId(Guid residentId, string team);
+        Guid AddResidentGroupId(Guid residentId, string team, Guid? groupId);
         Guid? FindGroupIdByResidentIdAndTeam(Guid residentId, string team);
 
     }

--- a/EvidenceApi/V1/Gateways/ResidentsGateway.cs
+++ b/EvidenceApi/V1/Gateways/ResidentsGateway.cs
@@ -85,14 +85,14 @@ namespace EvidenceApi.V1.Gateways
             return request;
         }
 
-        public Guid AddResidentGroupId(Guid residentId, string team)
+        public Guid AddResidentGroupId(Guid residentId, string team, Guid? groupId)
         {
-            var groupId = Guid.NewGuid();
-            var newEntry = new ResidentsTeamGroupId() { ResidentId = residentId, GroupId = groupId, Team = team };
+            var newGroupId = groupId ?? Guid.NewGuid();
+            var newEntry = new ResidentsTeamGroupId() { ResidentId = residentId, GroupId = newGroupId, Team = team };
 
             _databaseContext.ResidentsTeamGroupId.Add(newEntry);
             _databaseContext.SaveChanges();
-            return groupId;
+            return newGroupId;
         }
 
         public Guid? FindGroupIdByResidentIdAndTeam(Guid residentId, string team)

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionUseCase.cs
@@ -58,7 +58,7 @@ namespace EvidenceApi.V1.UseCase
             var groupId = _residentsGateway.FindGroupIdByResidentIdAndTeam(evidenceRequest.ResidentId, evidenceRequest.Team);
             if (groupId == null)
             {
-                groupId = _residentsGateway.AddResidentGroupId(evidenceRequest.ResidentId, evidenceRequest.Team);
+                groupId = _residentsGateway.AddResidentGroupId(evidenceRequest.ResidentId, evidenceRequest.Team, null);
             }
             try
             {

--- a/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateDocumentSubmissionWithoutEvidenceRequestUseCase.cs
@@ -48,7 +48,7 @@ namespace EvidenceApi.V1.UseCase
             {
                 try
                 {
-                    groupId = _residentsGateway.AddResidentGroupId(request.ResidentId, request.Team);
+                    groupId = _residentsGateway.AddResidentGroupId(request.ResidentId, request.Team, null);
                 }
                 catch (Exception)
                 {

--- a/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateEvidenceRequestUseCase.cs
@@ -52,7 +52,7 @@ namespace EvidenceApi.V1.UseCase
             }
 
             var resident = _residentsGateway.FindOrCreateResident(BuildResident(request.Resident));
-            _residentsGateway.AddResidentGroupId(resident.Id, request.Team);
+            _residentsGateway.AddResidentGroupId(resident.Id, request.Team, null);
             var documentTypes = request.DocumentTypes.ConvertAll<DocumentType>(dt => _documentTypeGateway.GetDocumentTypeByTeamNameAndDocumentTypeId(request.Team, dt));
 
             var residentReferenceId = _findOrCreateResidentReferenceIdUseCase.Execute(resident);

--- a/EvidenceApi/V1/UseCase/CreateResidentUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateResidentUseCase.cs
@@ -8,6 +8,7 @@ using EvidenceApi.V1.Boundary.Response.Exceptions;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using System;
+using System.Text.Json;
 
 namespace EvidenceApi.V1.UseCase
 {

--- a/EvidenceApi/V1/UseCase/CreateResidentUseCase.cs
+++ b/EvidenceApi/V1/UseCase/CreateResidentUseCase.cs
@@ -49,7 +49,7 @@ namespace EvidenceApi.V1.UseCase
             }
             var createdResident = _residentsGateway.CreateResident(resident);
 
-            _residentsGateway.AddResidentGroupId(createdResident.Id, request.Team);
+            _residentsGateway.AddResidentGroupId(createdResident.Id, request.Team, request.GroupId);
 
             return createdResident.ToResponse();
         }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1394?atlOrigin=eyJpIjoiNjhhYjdkYjFmNmNmNDkzNGI2ZGI3MTRjNjRiZmUxMDkiLCJwIjoiaiJ9

## Describe this PR

This PR changes the shape of the ResidentRequest object, allowing a groupId to be passed in from the front end. If the groupId is passed in (from an integration with an external system) then this is used in the creation of the resident. If no groupId is passed in, one is generated.

### *What changes have we introduced*

Update method signatures to allow a groupId to be passed in. In the AddResidentGroupId gateway method, check if the groupId parameter is populated. If it is, use it in the database insert.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test in staging.
