### PR TITLE
Pin serverless to v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Build lambda
           command: |


### PR DESCRIPTION
We don't want serverless to raise above version 3 for the moment, as it will need more configuration.