### PR TITLE
TS-1906: Returning an empty list if only the team is passed

### DIFF
--- a/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
+++ b/EvidenceApi.Tests/V1/E2ETests/EvidenceRequestsTest.cs
@@ -360,20 +360,6 @@ namespace EvidenceApi.Tests.V1.E2ETests
             // Assert
             response.StatusCode.Should().Be(400);
         }
-        [Test]
-        public async Task CanGetEvidenceRequestsWithValidService()
-        {
-            var expected = BuildEvidenceRequestsListWithSameResident();
-            var team = expected[0].Team;
-            var uri = new Uri($"api/v1/evidence_requests?team={team}", UriKind.Relative);
-            var response = await Client.GetAsync(uri);
-            var json = await response.Content.ReadAsStringAsync();
-            var result = JsonConvert.DeserializeObject<List<EvidenceRequestResponse>>(json);
-
-            response.StatusCode.Should().Be(200);
-            result.Should().ContainSingle();
-            result.Should().ContainEquivalentOf(expected[0]);
-        }
 
         [Test]
         public async Task CanGetEvidenceRequestsWithValidServiceAndResidentId()

--- a/EvidenceApi.Tests/V1/Gateways/EvidenceGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/EvidenceGatewayTests.cs
@@ -264,6 +264,19 @@ namespace EvidenceApi.Tests.V1.Gateways
         }
 
         [Test]
+        public void WillReturnEmptyListIfOnlyTeamIsPassed()
+        {
+            var request = new EvidenceRequestsSearchQuery()
+            {
+                Team = "development-team-staging",
+                ResidentId = null,
+                State = null
+            };
+            var result = _classUnderTest.GetEvidenceRequests(request);
+            result.Should().BeEmpty();
+        }
+
+        [Test]
         public void CanGetEvidenceRequestsByServiceAndResidentId()
         {
             var resident = TestDataHelper.Resident();

--- a/EvidenceApi.Tests/V1/Gateways/EvidenceGatewayTests.cs
+++ b/EvidenceApi.Tests/V1/Gateways/EvidenceGatewayTests.cs
@@ -295,19 +295,6 @@ namespace EvidenceApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void CanGetEvidenceRequestsByServiceOnly()
-        {
-            var request = new EvidenceRequestsSearchQuery()
-            {
-                Team = "development-team-staging"
-            };
-            var expected = ExpectedEvidenceRequestsWithService(request);
-
-            var result = _classUnderTest.GetEvidenceRequests(request);
-            result.Should().BeEquivalentTo(expected);
-        }
-
-        [Test]
         public void GetEvidenceRequestsReturnsEmptyList()
         {
             var request = new EvidenceRequestsSearchQuery()

--- a/EvidenceApi/V1/Gateways/EvidenceGateway.cs
+++ b/EvidenceApi/V1/Gateways/EvidenceGateway.cs
@@ -64,12 +64,17 @@ namespace EvidenceApi.V1.Gateways
 
         public List<EvidenceRequest> GetEvidenceRequests(EvidenceRequestsSearchQuery request)
         {
-            return _databaseContext.EvidenceRequests
-                .Where(x =>
-                    x.Team.Equals(request.Team) &&
-                    (request.ResidentId == null || x.ResidentId.Equals(request.ResidentId)) &&
-                    (request.State == null || x.State.Equals(request.State))
-                ).ToList();
+           if (request.ResidentId == null && request.State == null && request.Team != null) 
+           {
+                return new List<EvidenceRequest>();
+           }
+
+        return _databaseContext.EvidenceRequests
+            .Where(x =>
+                x.Team.Equals(request.Team) &&
+                (request.ResidentId == null || x.ResidentId.Equals(request.ResidentId)) &&
+                (request.State == null || x.State.Equals(request.State))
+            ).ToList();
         }
 
         public List<EvidenceRequest> GetEvidenceRequestsWithDocumentSubmissions(EvidenceRequestsSearchQuery request)

--- a/EvidenceApi/V1/Gateways/EvidenceGateway.cs
+++ b/EvidenceApi/V1/Gateways/EvidenceGateway.cs
@@ -64,17 +64,17 @@ namespace EvidenceApi.V1.Gateways
 
         public List<EvidenceRequest> GetEvidenceRequests(EvidenceRequestsSearchQuery request)
         {
-           if (request.ResidentId == null && request.State == null && request.Team != null) 
-           {
+            if (request.ResidentId == null && request.State == null && request.Team != null)
+            {
                 return new List<EvidenceRequest>();
-           }
+            }
 
-        return _databaseContext.EvidenceRequests
-            .Where(x =>
-                x.Team.Equals(request.Team) &&
-                (request.ResidentId == null || x.ResidentId.Equals(request.ResidentId)) &&
-                (request.State == null || x.State.Equals(request.State))
-            ).ToList();
+            return _databaseContext.EvidenceRequests
+                .Where(x =>
+                    x.Team.Equals(request.Team) &&
+                    (request.ResidentId == null || x.ResidentId.Equals(request.ResidentId)) &&
+                    (request.State == null || x.State.Equals(request.State))
+                ).ToList();
         }
 
         public List<EvidenceRequest> GetEvidenceRequestsWithDocumentSubmissions(EvidenceRequestsSearchQuery request)


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1906

## Describe this PR

There is an issue with DES atm, whereby the evidence-api is response is exceeding the lambda payload size limit upon being called with the team only.
This PR attempts to remediate that, by returning an empty list if only the team is passed.