### PR TITLE
Switch to the Cognito authorizer on `staging` environment.

### DIFF
--- a/EvidenceApi/serverless.yml
+++ b/EvidenceApi/serverless.yml
@@ -106,7 +106,7 @@ resources:
 
 custom:
   authorizerArns:
-    staging:    arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    staging:    arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
     production: arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   vpc:
     staging:


### PR DESCRIPTION
# What:
 - Switch to the Cognito authorizer on `staging` environment.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `staging`.

# Notes:
 - This repository and application does not have the `development` environment much like the Documents API doesn't. This is because this repository is a clone of a Documents API repository after the `development` environment's workflow has been removed _(see Document API's commit [[86df21fd](https://github.com/LBHackney-IT/documents-api/commit/86df21fdf363b71773303b7246b0bcec84051971)])_ from the CCI pipeline configuration. See Evidence API's commit [[e2904b46](https://github.com/LBHackney-IT/evidence-api/commit/e2904b462aea79a6c73734f42f7277e2da3e8aa8#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47)].