### PR TITLE
Change active maintainers to shared services team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/targeted-services
+* @LBHackney-IT/shared-services

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: build-local
 build-local:
-	docker-compose -f EvidenceApi/compose.yml build
+	docker compose -f EvidenceApi/compose.yml build
 
 .PHONY: build-test
 build-test:
-	docker-compose -f EvidenceApi.Tests/compose.yml build
+	docker compose -f EvidenceApi.Tests/compose.yml build
 
 .PHONY: serve-local
 serve-local:
@@ -16,7 +16,7 @@ serve-test:
 
 .PHONY: shell
 shell:
-	docker-compose run evidence-api bash
+	docker compose run evidence-api bash
 
 .PHONY: start-local
 start-local:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Evidence API
 
-Evidence API is a Platform API to allow services to request and upload evidence from members of the borough.   
+Evidence API is a Platform API to allow services to request and upload evidence from members of the borough.
 
 ## Stack
 
@@ -219,18 +219,7 @@ To update the accepted MIME types on the server, navigate to [AcceptedMimeTypes.
 
 ### Active Maintainers
 
--   **Selwyn Preston**, Lead Developer at London Borough of Hackney (selwyn.preston@hackney.gov.uk)
--   **Mirela Georgieva**, Lead Developer at London Borough of Hackney (mirela.georgieva@hackney.gov.uk)
--   **Matt Keyworth**, Lead Developer at London Borough of Hackney (matthew.keyworth@hackney.gov.uk)
-
-### Contributors
-
--   **Neil Mendum**, Senior Engineer at Made Tech (neil.mendum@hackney.gov.uk)
--   **Bogdan Zaharia**, Engineer at Made Tech (bogdan.zaharia@hackney.gov.uk)
-
-### Other Contacts
-
--   **Rashmi Shetty**, Product Owner at London Borough of Hackney (rashmi.shetty@hackney.gov.uk)
+-   **Shared Services team**, Maintenance team (shared.services@hackney.gov.uk)
 
 [docker-download]: https://www.docker.com/products/docker-desktop
 [universal-housing-simulator]: https://github.com/LBHackney-IT/lbh-universal-housing-simulator


### PR DESCRIPTION
### What & Why
Update the readme and code owners to specify the shared services team as the active maintainers. This is to provide a fresh pipeline for the auth switchover which will happen soon after.